### PR TITLE
Fix simulation tick call in Game.gd

### DIFF
--- a/scripts/Game.gd
+++ b/scripts/Game.gd
@@ -102,9 +102,9 @@ func _on_ask_ai(player_id: int) -> void:
 		aibr.suggest_for_player(player_id)
 
 func _on_tick() -> void:
-	Sim.step()
-	_update_status()
-	map_node.queue_redraw()
+        Sim.tick()
+        _update_status()
+        map_node.queue_redraw()
 
 func _on_cmd(text: String) -> void:
 	var t := text.strip_edges()


### PR DESCRIPTION
## Summary
- call `Sim.tick()` in `_on_tick` instead of missing `Sim.step()`

## Testing
- `godot --headless --test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa722e40c0832881e8b00213b33336