### PR TITLE
feat: improve map markers

### DIFF
--- a/scripts/Map.gd
+++ b/scripts/Map.gd
@@ -8,12 +8,21 @@ const IMG_SIZE: Vector2i = Vector2i(1536, 1024)
 
 var scale_val: float = 1.0
 var offset: Vector2 = Vector2.ZERO
+var player_blink: float = 0.0
+var hover_loc: String = ""
+var hover_scale: float = 1.0
+var _hover_tween: Tween = null
 
 func _ready() -> void:
-	mouse_filter = MOUSE_FILTER_STOP
-	_update_layout()
-	resized.connect(_on_resized)
-	queue_redraw()
+        mouse_filter = MOUSE_FILTER_STOP
+        _update_layout()
+        resized.connect(_on_resized)
+        set_process(true)
+        var blink := create_tween()
+        blink.set_loops(0)  # nieskończona pulsacja
+        blink.tween_property(self, "player_blink", 1.0, 0.5)
+        blink.tween_property(self, "player_blink", 0.0, 0.5)
+        queue_redraw()
 
 func _on_resized() -> void:
 	_update_layout()
@@ -41,8 +50,8 @@ func _draw() -> void:
 	if show_grid:
 		_draw_grid()
 	_draw_routes()
-	_draw_locations()
-	_draw_players()
+        _draw_locations()
+        _draw_players()
 
 func _draw_grid() -> void:
 	var step: int = 128
@@ -74,18 +83,22 @@ func _draw_routes() -> void:
 		draw_line(pa, pb, line, 3.0)
 
 func _draw_locations() -> void:
-	var font := get_theme_default_font()
-	# rysuj w stabilnej kolejności po kodach
-	var ids: Array = DB.positions.keys()
-	ids.sort()
-	for loc_id in ids:
-		var pos: Vector2 = DB.positions[loc_id]
-		# marker: kropka z ciemnym środkiem
-		draw_circle(pos, 7.0, Color(0.95, 0.3, 0.2, 0.9))
-		draw_circle(pos, 2.5, Color(0.1, 0.1, 0.1, 1.0))
-		# podpis (tłumaczona nazwa)
-		var label_pos := pos + Vector2(12, -8)
-		var name_str: String = DB.get_loc_name(loc_id)
+        var font := get_theme_default_font()
+        # rysuj w stabilnej kolejności po kodach
+        var ids: Array = DB.positions.keys()
+        ids.sort()
+        for loc_id in ids:
+                var pos: Vector2 = DB.positions[loc_id]
+                var radius: float = 10.5
+                if loc_id == hover_loc:
+                        radius *= hover_scale
+                        draw_circle(pos, radius + 2.0, Color.WHITE)
+                # marker: kropka z ciemnym środkiem
+                draw_circle(pos, radius, Color(0.95, 0.3, 0.2, 0.9))
+                draw_circle(pos, 3.75, Color(0.1, 0.1, 0.1, 1.0))
+                # podpis (tłumaczona nazwa)
+                var label_pos := pos + Vector2(12, -8)
+                var name_str: String = DB.get_loc_name(loc_id)
 		# cień
 		draw_string(font, label_pos + Vector2(1, 1), name_str, HORIZONTAL_ALIGNMENT_LEFT, -1, 16, Color(0, 0, 0, 0.65))
 		# właściwy napis
@@ -101,7 +114,7 @@ func _draw_players() -> void:
 	var idx: int = 0
 	var players: Array = players_dict.values()  # <-- kluczowa zmiana: Array z wartości słownika
 
-	for p in players:
+        for p in players:
 		# oczekujemy słownika z kluczami: "pos" (Vector2) LUB "loc" (kod DB)
 		var pos: Vector2 = Vector2.ZERO
 		if p.has("pos"):
@@ -111,23 +124,48 @@ func _draw_players() -> void:
 		else:
 			continue
 
-		var c: Color = colors[idx % colors.size()]
-		idx += 1
+                var c: Color = colors[idx % colors.size()]
+                idx += 1
 
-		var disp_label: String = "P"
-		if p.has("name"):
-			disp_label = String(p["name"])
+                var disp_label: String = "P"
+                if p.has("name"):
+                        disp_label = String(p["name"])
 
-		draw_circle(pos, 8.0, c)
-		draw_string(font, pos + Vector2(12, -8), disp_label, HORIZONTAL_ALIGNMENT_LEFT, -1, 16, c)
+                var scale := 1.0 + 0.3 * player_blink
+                var tri := PackedVector2Array([
+                        Vector2(0, -10) * scale + pos,
+                        Vector2(7, 10) * scale + pos,
+                        Vector2(-7, 10) * scale + pos,
+                ])
+                draw_colored_polygon(tri, c)
+                draw_string(font, pos + Vector2(12, -8), disp_label, HORIZONTAL_ALIGNMENT_LEFT, -1, 16, c)
 
 func _gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		# Przelicz klik ze space UI → space obrazu
-		var click_pos: Vector2 = _to_image(event.position)
-		# Trafienie w lokację po okręgu ~12 px
-		for loc_id in DB.positions.keys():
-			var p: Vector2 = DB.positions[loc_id]
-			if p.distance_to(click_pos) <= 12.0:
-				emit_signal("location_clicked", loc_id)
-				break
+        if event is InputEventMouseMotion:
+                var mouse_pos: Vector2 = _to_image(event.position)
+                var found: String = ""
+                for loc_id in DB.positions.keys():
+                        var p: Vector2 = DB.positions[loc_id]
+                        if p.distance_to(mouse_pos) <= 18.0:
+                                found = loc_id
+                                break
+                if found != hover_loc:
+                        hover_loc = found
+                        if _hover_tween != null:
+                                _hover_tween.kill()
+                        _hover_tween = create_tween()
+                        var target: float = hover_loc == "" ? 1.0 : 1.1
+                        _hover_tween.tween_property(self, "hover_scale", target, 0.1)
+                        queue_redraw()
+        elif event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                # Przelicz klik ze space UI → space obrazu
+                var click_pos: Vector2 = _to_image(event.position)
+                # Trafienie w lokację po większym okręgu
+                for loc_id in DB.positions.keys():
+                        var p: Vector2 = DB.positions[loc_id]
+                        if p.distance_to(click_pos) <= 18.0:
+                                emit_signal("location_clicked", loc_id)
+                                break
+
+func _process(_delta: float) -> void:
+        queue_redraw()


### PR DESCRIPTION
## Summary
- Enlarge and highlight city markers with hover feedback and larger click area
- Add animated triangular player markers with pulsating tween
- Enable continuous redraw for real-time marker updates

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa749d207083289c005f0d49fe237d