### PR TITLE
Add caravan sprite system for players on map

### DIFF
--- a/scenes/CaravanSprite.tscn
+++ b/scenes/CaravanSprite.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://scripts/CaravanSprite.gd" type="Script" id=1]
+
+[node name="CaravanSprite" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Anim" type="AnimatedSprite2D" parent="."]

--- a/scripts/CaravanSprite.gd
+++ b/scripts/CaravanSprite.gd
@@ -1,0 +1,67 @@
+extends Node2D
+class_name CaravanSprite
+
+enum CaravanState { CART, CART_HORSE, WAGON_2H, CAMELS, BROKEN, HIDDEN }
+
+@onready var anim: AnimatedSprite2D = $Anim
+
+var state: CaravanState = CaravanState.CART
+var direction: String = "down"
+var speed: float = 0.0
+
+func _ready() -> void:
+    _setup_frames()
+    _apply()
+
+func _setup_frames() -> void:
+    if anim.frames != null:
+        return
+    var frames := SpriteFrames.new()
+    var img := Image.create(8, 8, false, Image.FORMAT_RGBA8)
+    img.fill(Color.WHITE)
+    var tex := ImageTexture.create_from_image(img)
+    var states = ["cart", "cart_horse", "wagon_2h", "camels", "broken", "hidden"]
+    var dirs = ["up", "down", "left", "right"]
+    var modes = ["idle", "walk"]
+    for s in states:
+        for d in dirs:
+            for m in modes:
+                var anim_name = "%s_%s_%s" % [s, d, m]
+                frames.add_animation(anim_name)
+                frames.add_frame(anim_name, tex)
+    anim.frames = frames
+
+func set_state(p_state: CaravanState) -> void:
+    state = p_state
+    _apply()
+
+func set_direction(p_dir: String) -> void:
+    direction = p_dir
+    _apply()
+
+func set_speed(p_speed: float) -> void:
+    speed = p_speed
+    _apply()
+
+func _apply() -> void:
+    if anim.frames == null:
+        return
+    var state_name := match state:
+        CaravanState.CART: "cart"
+        CaravanState.CART_HORSE: "cart_horse"
+        CaravanState.WAGON_2H: "wagon_2h"
+        CaravanState.CAMELS: "camels"
+        CaravanState.BROKEN: "broken"
+        CaravanState.HIDDEN: "hidden"
+        _: "cart"
+    var mode := "idle" if abs(speed) < 0.01 else "walk"
+    var anim_name := "%s_%s_%s" % [state_name, direction, mode]
+    if anim.frames.has_animation(anim_name):
+        anim.play(anim_name)
+    anim.speed_scale = max(0.01, abs(speed))
+    if state == CaravanState.BROKEN:
+        anim.modulate = Color(1, 0.3, 0.3)
+    elif state == CaravanState.HIDDEN:
+        anim.modulate = Color(1, 1, 1, 0.3)
+    else:
+        anim.modulate = Color(1, 1, 1, 1)

--- a/scripts/CaravanSprite.gd.uid
+++ b/scripts/CaravanSprite.gd.uid
@@ -1,0 +1,1 @@
+uid://te4p3tmcrqaep


### PR DESCRIPTION
## Summary
- Add `CaravanSprite` scene and script with state-driven animations, direction handling, and speed-based playback
- Integrate caravan sprites into `Map.gd`, tracking one sprite per player with state, direction, and speed updates

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7d0b10b0832883614e320e81da8a