### PR TITLE
Place status bar at bottom with time controls

### DIFF
--- a/scenes/Game.tscn
+++ b/scenes/Game.tscn
@@ -21,6 +21,7 @@ grow_vertical = 2
 anchors_preset = 0
 anchor_right = 0.72
 anchor_bottom = 1.0
+offset_bottom = -28.0
 
 [node name="Map" type="Control" parent="UI/Left"]
 anchors_preset = 0
@@ -37,54 +38,58 @@ mouse_filter = 2
 texture = ExtResource("5")
 stretch_mode = 4
 
+
 [node name="Right" type="Control" parent="UI"]
 anchors_preset = 0
 anchor_left = 0.72
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = -28.0
 
-[node name="Status" type="HBoxContainer" parent="UI/Right"]
+[node name="Status" type="HBoxContainer" parent="UI"]
 layout_mode = 0
 anchor_right = 1.0
-offset_bottom = 28.0
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -28.0
 
-[node name="PlayerSel" type="OptionButton" parent="UI/Right/Status"]
+[node name="PlayerSel" type="OptionButton" parent="UI/Status"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Gold" type="Label" parent="UI/Right/Status"]
+[node name="Gold" type="Label" parent="UI/Status"]
 layout_mode = 2
 text = "Gold: 0"
 
-[node name="Caravans" type="Label" parent="UI/Right/Status"]
+[node name="Caravans" type="Label" parent="UI/Status"]
 layout_mode = 2
 text = "Caravans: 0"
 
-[node name="Tick" type="Label" parent="UI/Right/Status"]
+[node name="Tick" type="Label" parent="UI/Status"]
 layout_mode = 2
 text = "Tick: 0"
 
-[node name="Loc" type="Label" parent="UI/Right/Status"]
+[node name="Loc" type="Label" parent="UI/Status"]
 layout_mode = 2
 text = "Location: Colony"
 
-[node name="Cap" type="Label" parent="UI/Right/Status"]
+[node name="Cap" type="Label" parent="UI/Status"]
 layout_mode = 2
 text = "Cargo: 0/0"
 
-[node name="Speed" type="Label" parent="UI/Right/Status"]
+[node name="Speed" type="Label" parent="UI/Status"]
 layout_mode = 2
 text = "Speed: 1.0"
 
-[node name="PauseBtn" type="Button" parent="UI/Right/Status"]
+[node name="PauseBtn" type="Button" parent="UI/Status"]
 layout_mode = 2
 text = "||"
 
-[node name="PlayBtn" type="Button" parent="UI/Right/Status"]
+[node name="PlayBtn" type="Button" parent="UI/Status"]
 layout_mode = 2
 text = ">"
 
-[node name="FastBtn" type="Button" parent="UI/Right/Status"]
+[node name="FastBtn" type="Button" parent="UI/Status"]
 layout_mode = 2
 text = ">>"
 

--- a/scripts/Game.gd
+++ b/scripts/Game.gd
@@ -6,17 +6,17 @@ extends Node
 @onready var help_box: RichTextLabel = $UI/Right/Tabs/Help/HelpText
 @onready var tab: TabContainer = $UI/Right/Tabs
 
-@onready var player_selector: OptionButton = $UI/Right/Status/PlayerSel
-@onready var gold_label: Label = $UI/Right/Status/Gold
-@onready var caravans_label: Label = $UI/Right/Status/Caravans
-@onready var tick_label: Label = $UI/Right/Status/Tick
-@onready var loc_label: Label = $UI/Right/Status/Loc
-@onready var cap_label: Label = $UI/Right/Status/Cap
-@onready var speed_label: Label = $UI/Right/Status/Speed
+@onready var player_selector: OptionButton = $UI/Status/PlayerSel
+@onready var gold_label: Label = $UI/Status/Gold
+@onready var caravans_label: Label = $UI/Status/Caravans
+@onready var tick_label: Label = $UI/Status/Tick
+@onready var loc_label: Label = $UI/Status/Loc
+@onready var cap_label: Label = $UI/Status/Cap
+@onready var speed_label: Label = $UI/Status/Speed
 
-@onready var pause_btn: Button = $UI/Right/Status/PauseBtn
-@onready var play_btn: Button = $UI/Right/Status/PlayBtn
-@onready var fast_btn: Button = $UI/Right/Status/FastBtn
+@onready var pause_btn: Button = $UI/Status/PauseBtn
+@onready var play_btn: Button = $UI/Status/PlayBtn
+@onready var fast_btn: Button = $UI/Status/FastBtn
 
 @onready var lang_option: OptionButton = $UI/Right/Tabs/Options/Lang
 


### PR DESCRIPTION
## Summary
- Move status bar to the bottom of the screen so it spans the full window width
- Wire status bar paths and time control buttons after moving them to the root UI
- Shorten map and right-side panels to leave room for the status bar

## Testing
- `godot --headless --version`

------
https://chatgpt.com/codex/tasks/task_e_68ab23303de88328856296c300d0f890