### PR TITLE
Add development plan with staged checklist

### DIFF
--- a/plan/project-plan.md
+++ b/plan/project-plan.md
@@ -1,0 +1,52 @@
+# CaravanWars Project Plan
+
+This plan outlines stages of development for the CaravanWars game.
+Use the checkboxes to mark completed tasks.
+
+## Stage 0: Concept & Setup
+- [x] Create concept and design document
+- [x] Set up initial Godot project with basic scenes and scripts
+- [x] Establish development environment and build pipeline
+
+## Stage 1: World Simulation
+- [x] Implement location and goods data model
+- [x] Implement time/tick system across server and clients
+- [x] Basic economy: production, consumption and price fluctuations
+
+## Stage 2: Player & Caravan Management
+- [x] Player data model and persistence
+- [x] Caravan movement logic on the world map
+- [x] Cargo capacity and inventory management
+
+## Stage 3: Trade Mechanics
+- [x] Buying and selling goods at markets
+- [x] Price updates and knowledge base per player
+- [ ] Courier system for information transfer
+
+## Stage 4: UI & Map
+- [x] Basic UI with map, status bar and tabs
+- [x] Narrator, log and help panels
+- [ ] Responsive UI elements and localization
+
+## Stage 5: AI Integration
+- [ ] AI players operating under knowledge restrictions
+- [ ] External AI bridge for suggestions/automation
+
+## Stage 6: Combat
+- [ ] Tactical battle prototype for singleplayer
+- [ ] Auto-resolve combat for multiplayer
+
+## Stage 7: Multiplayer & Persistence
+- [x] Server architecture for persistent world
+- [x] Client networking layer
+- [ ] Support asynchronous play
+
+## Stage 8: Narrators & Events
+- [x] Global and local narrator systems
+- [ ] Event generation and delayed information spread
+
+## Stage 9: Polish & Release
+- [ ] Localization and translation pass
+- [ ] Performance optimization and bug fixing
+- [ ] Packaging and release preparation
+


### PR DESCRIPTION
## Summary
- add project planning document with stages and checkbox tasks
- mark networking, tick loop, narrator and basic economy tasks as completed to reflect existing code
- mark player management stage as complete, including player data, caravan movement and cargo handling
- mark trade mechanics tasks (buy/sell and price knowledge) as completed

## Testing
- `godot --headless -s scripts/test_economy.gd` *(fails: File not found)*
- `godot --version`


------
https://chatgpt.com/codex/tasks/task_e_68bb9000514c8328b31301983e9b88b8