### PR TITLE
Wrap trade grid in scroll container

### DIFF
--- a/scenes/panels/TradePanel.tscn
+++ b/scenes/panels/TradePanel.tscn
@@ -5,8 +5,13 @@
 script = ExtResource(1)
 anchor_right = 1.0
 anchor_bottom = 1.0
+ 
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 3
 
-[node name="Grid" type="GridContainer" parent="."]
+[node name="Grid" type="GridContainer" parent="ScrollContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 columns = 6

--- a/scripts/panels/TradePanel.gd
+++ b/scripts/panels/TradePanel.gd
@@ -2,7 +2,7 @@ extends VBoxContainer
 signal buy_request(good:int, amount:int)
 signal sell_request(good:int, amount:int)
 
-@onready var grid: GridContainer = $Grid
+@onready var grid: GridContainer = $ScrollContainer/Grid
 
 func _ready():
 	populate()


### PR DESCRIPTION
## Summary
- Add `ScrollContainer` to `TradePanel` scene and move grid inside it
- Update TradePanel script's `grid` reference to new node path

## Testing
- `godot --headless --path . --check` *(fails: Parse Error: [ext_resource] referenced non-existent resource)*

------
https://chatgpt.com/codex/tasks/task_e_68bc846ce4d8832892ad0fd1868e9d4e