### PR TITLE
Remove AI advice button and sync caravan tab with server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@
 - Order script sections: extends -> signals -> constants -> variables -> functions.
 - Use `@onready` for node references that depend on the scene tree.
 
+## Server Authority
+- The server is the single source of truth for all game state.
+- Client code must not make authoritative decisions; it should only display state or send requests.
+- All state updates and validations must go through the server.
+- Avoid duplicating server logic on the client; rely on data returned from the server instead.
+
 ## Prepare Merge Procedure
 When a user asks to "prepare merge":
 1. Run `git fetch origin` and merge the latest `origin/main` into the current branch.

--- a/autoload/PlayerMgr.gd
+++ b/autoload/PlayerMgr.gd
@@ -7,97 +7,108 @@ var order := []
 var local_player_id : int = 1
 
 func _ready():
-	add_player(1, "Player A", Kind.HUMAN, "CENTRAL_KEEP")
-	add_player(2, "Player B", Kind.HUMAN, "HARBOR")
-	add_player(101, "Guild AI", Kind.AI, "MINE")
-	order = [1,2,101]
+    add_player(1, "Player A", Kind.HUMAN, "CENTRAL_KEEP")
+    add_player(2, "Player B", Kind.HUMAN, "HARBOR")
+    add_player(101, "Guild AI", Kind.AI, "MINE")
+    order = [1,2,101]
 
 func add_player(id:int, name:String, kind:int, start_loc:String):
-	players[id] = {
-		"name":name, "kind":kind, "loc":start_loc, "gold":150,
-		"units":["hand_cart"],
-		"cargo":{},
-		"moving":false, "progress":0.0
-	}
+    players[id] = {
+        "name":name, "kind":kind, "loc":start_loc, "gold":150,
+        "units":["hand_cart"],
+        "cargo":{},
+        "moving":false, "progress":0.0
+    }
 
 func is_moving(id:int) -> bool:
-	var p = players.get(id, null)
-	return p != null and p.get("moving", false)
+    var p = players.get(id, null)
+    return p != null and p.get("moving", false)
 
 func calc_speed(id:int) -> float:
-	var p = players[id]
-	var defs = DB.unit_defs
-	var sp := 9999.0
-	for u in p["units"]:
-		var d = defs.get(u, null)
-		if d == null: continue
-		sp = min(sp, float(d.get("speed", 1.0)))
-	if sp == 9999.0: sp = 1.0
-	return sp
+    var p = players[id]
+    var defs = DB.unit_defs
+    var sp := 9999.0
+    for u in p["units"]:
+        var d = defs.get(u, null)
+        if d == null: continue
+        sp = min(sp, float(d.get("speed", 1.0)))
+    if sp == 9999.0: sp = 1.0
+    return sp
 
 func capacity_total(id:int) -> int:
-	var p = players[id]
-	var defs = DB.unit_defs
-	var cap := 0
-	for u in p["units"]:
-		var d = defs.get(u, null)
-		if d == null: continue
-		cap += int(d.get("capacity", 0))
-	return cap
+    var p = players[id]
+    var defs = DB.unit_defs
+    var cap := 0
+    for u in p["units"]:
+        var d = defs.get(u, null)
+        if d == null: continue
+        cap += int(d.get("capacity", 0))
+    return cap
 
 func cargo_used(id:int) -> int:
-	var p = players[id]
-	var used := 0
-	for g in p["cargo"].keys():
-		used += int(p["cargo"][g])
-	return used
+    var p = players[id]
+    var used := 0
+    for g in p["cargo"].keys():
+        used += int(p["cargo"][g])
+    return used
 
 func cargo_free(id:int) -> int:
-	return max(0, capacity_total(id) - cargo_used(id))
+    return max(0, capacity_total(id) - cargo_used(id))
 
 func cargo_amount(id:int, good:int) -> int:
-	var p = players.get(id, {})
-	return int(p.get("cargo", {}).get(good, 0))
+    var p = players.get(id, {})
+    return int(p.get("cargo", {}).get(good, 0))
 
 func cargo_add(id:int, good:int, qty:int) -> void:
-	if qty <= 0:
-		return
-	var p = players.get(id, {})
-	var c: Dictionary = p.get("cargo", {})
-	c[good] = int(c.get(good, 0)) + qty
-	p["cargo"] = c
+    if qty <= 0:
+        return
+    var p = players.get(id, {})
+    var c: Dictionary = p.get("cargo", {})
+    c[good] = int(c.get(good, 0)) + qty
+    p["cargo"] = c
 
 func cargo_remove(id:int, good:int, qty:int) -> void:
-	if qty <= 0:
-		return
-	var p = players.get(id, {})
-	var c: Dictionary = p.get("cargo", {})
-	var have := int(c.get(good, 0))
-	var left = int(max(0, have - qty))
-	if left > 0:
-		c[good] = left
-	else:
-		if c.has(good):
-			c.erase(good)
-	p["cargo"] = c
+        if qty <= 0:
+                return
+        var p = players.get(id, {})
+        var c: Dictionary = p.get("cargo", {})
+        var have := int(c.get(good, 0))
+        var left = int(max(0, have - qty))
+        if left > 0:
+                c[good] = left
+        else:
+                if c.has(good):
+                        c.erase(good)
+        p["cargo"] = c
+
+func food_rate(id: int) -> int:
+        var p: Dictionary = players.get(id, {})
+        var defs: Dictionary = DB.unit_defs
+        var total: int = 0
+        for u in p.get("units", []):
+                var d: Dictionary = defs.get(u, {})
+                if d.is_empty():
+                        continue
+                total += int(d.get("upkeep_food", 0))
+        return total
 
 func start_travel(id:int, to_loc:String) -> bool:
-	var p = players[id]
-	if p.get("moving", false): return false
-	var from_loc = p["loc"]
-	if from_loc == to_loc: return false
-	var key = "%s->%s" % [from_loc, to_loc]
-	if not DB.routes.has(key): return false
-	var base_ticks = int(DB.routes[key]["ticks"]) * 5
-	var speed = max(0.1, calc_speed(id))
-	var eta = float(base_ticks) / speed
-	p["moving"] = true
-	p["from"] = from_loc
-	p["to"] = to_loc
-	p["eta_left"] = eta
-	p["eta_total"] = eta
-	p["progress"] = 0.0
-	var srv = get_node_or_null("/root/Server")
-	if srv != null:
-		srv.call_deferred("broadcast_log", tr("[%s] traveling %s -> %s (ETA %.1f).") % [p["name"], DB.get_loc_name(from_loc), DB.get_loc_name(to_loc), eta])
-	return true
+        var p = players[id]
+        if p.get("moving", false): return false
+        var from_loc = p["loc"]
+        if from_loc == to_loc: return false
+        var key = "%s->%s" % [from_loc, to_loc]
+        if not DB.routes.has(key): return false
+        var base_ticks = int(DB.routes[key]["ticks"]) * 5
+        var speed = max(0.1, calc_speed(id))
+        var eta = float(base_ticks) / speed
+        p["moving"] = true
+        p["from"] = from_loc
+        p["to"] = to_loc
+        p["eta_left"] = eta
+        p["eta_total"] = eta
+        p["progress"] = 0.0
+        var srv = get_node_or_null("/root/Server")
+        if srv != null:
+                srv.call_deferred("broadcast_log", tr("[%s] traveling %s -> %s (ETA %.1f).") % [p["name"], DB.get_loc_name(from_loc), DB.get_loc_name(to_loc), eta])
+        return true

--- a/locale/translations.pl.tres
+++ b/locale/translations.pl.tres
@@ -19,7 +19,6 @@ messages = {
     "Goods: {}": "Towary: {}",
     "Food/day: 0": "Jedzenie/dzień: 0",
     "Speed: 0": "Prędkość: 0",
-    "Ask AI for advice": "Poproś AI o poradę",
     "Cheats": "Oszustwa",
     "Chronicle": "Kronika",
     "Caravan": "Karawana",

--- a/scenes/panels/CaravanPanel.tscn
+++ b/scenes/panels/CaravanPanel.tscn
@@ -18,5 +18,3 @@ text = "Food/day: 0"
 [node name="Speed" type="Label" parent="."]
 text = "Speed: 0"
 
-[node name="AskAI" type="Button" parent="."]
-text = "Ask AI for advice"

--- a/scripts/Game.gd
+++ b/scripts/Game.gd
@@ -33,166 +33,178 @@ var last_stock: Dictionary = {}
 var last_moving: bool = false
 
 func _ready() -> void:
-	# log setup (console removed; logs come from Server/Client)
+    # log setup (console removed; logs come from Server/Client)
 
-	# tick + mapa
-	tick_timer.timeout.connect(_on_tick)
-	if map_node.has_signal("location_clicked"):
-		map_node.location_clicked.connect(_on_location_click)
-		zoom_in_btn.pressed.connect(map_node.zoom_in)
-		zoom_out_btn.pressed.connect(map_node.zoom_out)
+    # tick + mapa
+    tick_timer.timeout.connect(_on_tick)
+    if map_node.has_signal("location_clicked"):
+        map_node.location_clicked.connect(_on_location_click)
+        zoom_in_btn.pressed.connect(map_node.zoom_in)
+        zoom_out_btn.pressed.connect(map_node.zoom_out)
 
-	# trade panel
-	if trade_panel.has_signal("buy_request"):
-		trade_panel.buy_request.connect(_on_buy_request)
-	if trade_panel.has_signal("sell_request"):
-		trade_panel.sell_request.connect(_on_sell_request)
+    # trade panel
+    if trade_panel.has_signal("buy_request"):
+        trade_panel.buy_request.connect(_on_buy_request)
+    if trade_panel.has_signal("sell_request"):
+        trade_panel.sell_request.connect(_on_sell_request)
 
-	# inne panele (opcjonalnie)
-	if caravan_panel.has_signal("ask_ai_pressed"):
-		caravan_panel.ask_ai_pressed.connect(_on_ask_ai)
-	if WorldViewModel.has_signal("player_changed"):
-		WorldViewModel.player_changed.connect(_on_player_changed)
+        # inne panele (opcjonalnie)
+        if WorldViewModel.has_signal("player_changed"):
+                WorldViewModel.player_changed.connect(_on_player_changed)
 
-	_fill_help()
-	_setup_language_dropdown()
-	_setup_time_controls()
-	_set_tab_titles()
-	_update_status()
-	map_node.queue_redraw()
-	_set_time_factor(time_factor)
-	set_process(true)
-	_store_trade_state()
+    _fill_help()
+    _setup_language_dropdown()
+    _setup_time_controls()
+    _set_tab_titles()
+    _update_status()
+    map_node.queue_redraw()
+    _set_time_factor(time_factor)
+    set_process(true)
+    _store_trade_state()
 
 func _fill_help() -> void:
-	var t := ""
-	t += "[b]" + tr("Caravan Wars {version}").format({"version": GAME_VERSION}) + "[/b]\n"
-	t += tr("• Move by clicking on the map (your caravan travels between locations).") + "\n"
-	t += tr("• Trade only in the current location.") + "\n"
-	t += tr("Codes: HARBOR, CENTRAL_KEEP, SOUTHERN_SHRINE, FOREST_SPRING, MILLS, FOREST_HAVEN, MINE") + "\n"
-	help_box.bbcode_enabled = true
-	help_box.clear()
-	help_box.append_text(t)
+    var t := ""
+    t += "[b]" + tr("Caravan Wars {version}").format({"version": GAME_VERSION}) + "[/b]\n"
+    t += tr("• Move by clicking on the map (your caravan travels between locations).") + "\n"
+    t += tr("• Trade only in the current location.") + "\n"
+    t += tr("Codes: HARBOR, CENTRAL_KEEP, SOUTHERN_SHRINE, FOREST_SPRING, MILLS, FOREST_HAVEN, MINE") + "\n"
+    help_box.bbcode_enabled = true
+    help_box.clear()
+    help_box.append_text(t)
 
 func _setup_language_dropdown() -> void:
-	lang_option.clear()
-	var langs := {"en": tr("English"), "pl": tr("Polski")}
-	for code in langs.keys():
-		lang_option.add_item(langs[code])
-		lang_option.set_item_metadata(lang_option.item_count - 1, code)
-	for i in range(lang_option.get_item_count()):
-		if lang_option.get_item_metadata(i) == DB.current_language:
-			lang_option.select(i)
-			break
-	lang_option.item_selected.connect(func(i):
-		DB.set_language(lang_option.get_item_metadata(i))
-		_fill_help()
-		_set_tab_titles()
-		caravan_panel.set_target(caravan_panel.selected_target)
-		caravan_panel.ask_ai_btn.text = tr("Ask AI for advice")
-		_update_status()
-		_refresh_trade_panel()
-		map_node.queue_redraw()
-	)
+    lang_option.clear()
+    var langs := {"en": tr("English"), "pl": tr("Polski")}
+    for code in langs.keys():
+        lang_option.add_item(langs[code])
+        lang_option.set_item_metadata(lang_option.item_count - 1, code)
+    for i in range(lang_option.get_item_count()):
+        if lang_option.get_item_metadata(i) == DB.current_language:
+            lang_option.select(i)
+            break
+    lang_option.item_selected.connect(func(i):
+        DB.set_language(lang_option.get_item_metadata(i))
+        _fill_help()
+        _set_tab_titles()
+        caravan_panel.set_target(caravan_panel.selected_target)
+        _update_status()
+        _refresh_trade_panel()
+        map_node.queue_redraw()
+        )
 
 func _setup_time_controls() -> void:
-	pause_btn.pressed.connect(func(): _set_time_factor(0.0))
-	play_btn.pressed.connect(func(): _set_time_factor(1.0))
-	fast_btn.pressed.connect(func(): _set_time_factor(2.0))
+    pause_btn.pressed.connect(func(): _set_time_factor(0.0))
+    play_btn.pressed.connect(func(): _set_time_factor(1.0))
+    fast_btn.pressed.connect(func(): _set_time_factor(2.0))
 
 func _set_time_factor(f: float) -> void:
-	time_factor = f
-	if f <= 0.0:
-		tick_timer.stop()
-	else:
-		tick_timer.start(1.0 / f)
+    time_factor = f
+    if f <= 0.0:
+        tick_timer.stop()
+    else:
+        tick_timer.start(1.0 / f)
 
 func _store_trade_state() -> void:
-	var pid = PlayerMgr.local_player_id
-	var p = PlayerMgr.players.get(pid, {})
-	last_loc = p.get("loc", "")
-	last_moving = p.get("moving", false)
-	var loc_obj = DB.get_loc(last_loc)
-	last_stock = loc_obj.stock.duplicate() if loc_obj else {}
+    var pid = PlayerMgr.local_player_id
+    var p = PlayerMgr.players.get(pid, {})
+    last_loc = p.get("loc", "")
+    last_moving = p.get("moving", false)
+    var loc_obj = DB.get_loc(last_loc)
+    last_stock = loc_obj.stock.duplicate() if loc_obj else {}
 
 func _refresh_trade_panel() -> void:
-	trade_panel.call_deferred("populate")
-	_store_trade_state()
+    trade_panel.call_deferred("populate")
+    _store_trade_state()
 
 func _check_trade_refresh() -> void:
-	var pid = PlayerMgr.local_player_id
-	var p = PlayerMgr.players.get(pid, null)
-	if p == null:
-		return
-	var loc = p.get("loc", "")
-	var moving = p.get("moving", false)
-	var loc_obj = DB.get_loc(loc)
-	var stock = loc_obj.stock.duplicate() if loc_obj else {}
-	if moving != last_moving or loc != last_loc or stock != last_stock:
-		_refresh_trade_panel()
+    var pid = PlayerMgr.local_player_id
+    var p = PlayerMgr.players.get(pid, null)
+    if p == null:
+        return
+    var loc = p.get("loc", "")
+    var moving = p.get("moving", false)
+    var loc_obj = DB.get_loc(loc)
+    var stock = loc_obj.stock.duplicate() if loc_obj else {}
+    if moving != last_moving or loc != last_loc or stock != last_stock:
+        _refresh_trade_panel()
 
 func _update_status() -> void:
-	var pid = PlayerMgr.local_player_id
-	var p = PlayerMgr.players.get(pid, null)
-	if p == null:
-		return
-	loc_label.text = tr("Location: {loc}").format({"loc": DB.get_loc_name(p.get("loc", ""))})
-	speed_label.text = tr("Speed: {value}").format({"value": str(PlayerMgr.calc_speed(pid))})
-	tick_label.text = tr("Tick: {value}").format({"value": str(Sim.tick_count)})
-	var used = PlayerMgr.cargo_used(pid)
-	var total = PlayerMgr.capacity_total(pid)
-	cap_label.text = tr("Cargo: {used}/{total}").format({"used": str(used), "total": str(total)})
-	gold_label.text = tr("Gold: {value}").format({"value": str(p.get("gold", 0))})
-	caravans_label.text = tr("Caravans: {value}").format({"value": str(p.get("units", []).size())})
+        var pid = PlayerMgr.local_player_id
+        var p = PlayerMgr.players.get(pid, null)
+        if p == null:
+                return
+        loc_label.text = tr("Location: {loc}").format({"loc": DB.get_loc_name(p.get("loc", ""))})
+        var speed_val: float = PlayerMgr.calc_speed(pid)
+        speed_label.text = tr("Speed: {value}").format({"value": str(speed_val)})
+        tick_label.text = tr("Tick: {value}").format({"value": str(Sim.tick_count)})
+        var used: int = PlayerMgr.cargo_used(pid)
+        var total: int = PlayerMgr.capacity_total(pid)
+        cap_label.text = tr("Cargo: {used}/{total}").format({"used": str(used), "total": str(total)})
+        gold_label.text = tr("Gold: {value}").format({"value": str(p.get("gold", 0))})
+        caravans_label.text = tr("Caravans: {value}").format({"value": str(p.get("units", []).size())})
+
+        var target: String = ""
+        if p.get("moving", false):
+                target = DB.get_loc_name(p.get("to", ""))
+        else:
+                target = DB.get_loc_name(p.get("loc", ""))
+        caravan_panel.set_target(target)
+
+        var goods_text: Array[String] = []
+        var cargo: Dictionary = p.get("cargo", {})
+        for g in cargo.keys():
+                var name: String = tr(DB.goods_names.get(g, str(g)))
+                goods_text.append("%s:%d" % [name, int(cargo[g])])
+        var status: Dictionary = {
+                "goods": ", ".join(goods_text),
+                "food_rate": PlayerMgr.food_rate(pid),
+                "speed": speed_val
+        }
+        caravan_panel.show_status(status)
 
 func _set_tab_titles() -> void:
-	tab.set_tab_title(0, tr("Chronicle"))
-	tab.set_tab_title(1, tr("Caravan"))
-	tab.set_tab_title(2, tr("Trade"))
-	tab.set_tab_title(3, tr("World"))
-	tab.set_tab_title(4, tr("Narrator"))
-	tab.set_tab_title(5, tr("Help"))
+    tab.set_tab_title(0, tr("Chronicle"))
+    tab.set_tab_title(1, tr("Caravan"))
+    tab.set_tab_title(2, tr("Trade"))
+    tab.set_tab_title(3, tr("World"))
+    tab.set_tab_title(4, tr("Narrator"))
+    tab.set_tab_title(5, tr("Help"))
 
 func _process(delta: float) -> void:
-	Sim.advance_players(delta * time_factor)
-	_update_status()
-	_check_trade_refresh()
+    Sim.advance_players(delta * time_factor)
+    _update_status()
+    _check_trade_refresh()
 
 func _on_location_click(loc_code: String) -> void:
-	var pid = PlayerMgr.local_player_id
-	Orders.order_move(str(pid), loc_code)
-	_update_status()
-	map_node.queue_redraw()
-	_refresh_trade_panel()
+    var pid = PlayerMgr.local_player_id
+    Orders.order_move(str(pid), loc_code)
+    _update_status()
+    map_node.queue_redraw()
+    _refresh_trade_panel()
 
 func _on_buy_request(good: int, amount: int) -> void:
-	var pid = PlayerMgr.local_player_id
-	var loc: String = PlayerMgr.players.get(pid, {}).get("loc", "")
-	Orders.order_buy(str(pid), loc, str(good), amount)
-	_update_status()
-	_refresh_trade_panel()
+    var pid = PlayerMgr.local_player_id
+    var loc: String = PlayerMgr.players.get(pid, {}).get("loc", "")
+    Orders.order_buy(str(pid), loc, str(good), amount)
+    _update_status()
+    _refresh_trade_panel()
 
 func _on_sell_request(good: int, amount: int) -> void:
-	var pid = PlayerMgr.local_player_id
-	var loc: String = PlayerMgr.players.get(pid, {}).get("loc", "")
-	Orders.order_sell(str(pid), loc, str(good), amount)
-	_update_status()
-	_refresh_trade_panel()
-
-func _on_ask_ai(player_id: int) -> void:
-	var aibr = get_node_or_null("/root/AiBridge")
-	if aibr:
-		aibr.suggest_for_player(player_id)
+    var pid = PlayerMgr.local_player_id
+    var loc: String = PlayerMgr.players.get(pid, {}).get("loc", "")
+    Orders.order_sell(str(pid), loc, str(good), amount)
+    _update_status()
+    _refresh_trade_panel()
 
 func _on_tick() -> void:
-	Sim.tick()
-	_update_status()
-	map_node.queue_redraw()
+        Sim.tick()
+        _update_status()
+        map_node.queue_redraw()
 
 func _on_log(msg: String) -> void:
-	log_label.append_text(msg + "\n")
+    log_label.append_text(msg + "\n")
 
 func _on_player_changed(_data: Dictionary) -> void:
-	_update_status()
-	_refresh_trade_panel()
-	map_node.queue_redraw()
+    _update_status()
+    _refresh_trade_panel()
+    map_node.queue_redraw()

--- a/scripts/panels/CaravanPanel.gd
+++ b/scripts/panels/CaravanPanel.gd
@@ -1,22 +1,17 @@
 extends VBoxContainer
-signal ask_ai_pressed(player_id:int)
 
 @onready var target_label: Label = $Target
 @onready var goods_label: Label = $Goods
 @onready var food_label: Label = $Food
 @onready var speed_label: Label = $Speed
-@onready var ask_ai_btn: Button = $AskAI
 
 var selected_target: String = ""
 
-func set_target(name:String):
-	selected_target = name
-	target_label.text = tr("Target: {name}").format({"name": name})
+func set_target(name: String) -> void:
+        selected_target = name
+        target_label.text = tr("Target: {name}").format({"name": name})
 
-func _ready():
-	ask_ai_btn.pressed.connect(func(): emit_signal("ask_ai_pressed", PlayerMgr.local_player_id))
-
-func show_status(data:Dictionary) -> void:
-	goods_label.text = tr("Goods: {goods}").format({"goods": str(data.get("goods", {}))})
-	food_label.text = tr("Food/day: {rate}").format({"rate": str(data.get("food_rate", 0))})
-	speed_label.text = tr("Speed: {value}").format({"value": str(data.get("speed", 0))})
+func show_status(data: Dictionary) -> void:
+        goods_label.text = tr("Goods: {goods}").format({"goods": str(data.get("goods", {}))})
+        food_label.text = tr("Food/day: {rate}").format({"rate": str(data.get("food_rate", 0))})
+        speed_label.text = tr("Speed: {value}").format({"value": str(data.get("speed", 0))})


### PR DESCRIPTION
## Summary
- drop unused Ask AI control from caravan panel
- show caravan target, goods, food usage and speed based on server state
- add helper to calculate caravan food consumption
- note in AGENTS that server is the single source of truth

## Testing
- `godot --headless --path . --check` *(fails: No loader found for resource: res://assets/ui/window_frame_256.png)*

------
https://chatgpt.com/codex/tasks/task_e_68bc88b681dc832885bed2ed0ca43451