### PR TITLE
Use snapshot-based UI updates

### DIFF
--- a/scripts/net/Client.gd
+++ b/scripts/net/Client.gd
@@ -1,6 +1,8 @@
 extends Node
 class_name Client
 
+signal snapshot_applied
+
 const Logger = preload("res://scripts/Logger.gd")
 
 @export var peer_id: int = 1
@@ -105,3 +107,4 @@ func push_snapshot(snapshot:Dictionary) -> void:
     # Notify UI viewmodels to refresh current selections
     if WorldViewModel and WorldViewModel.has_method("notify_data_changed"):
         WorldViewModel.notify_data_changed()
+    snapshot_applied.emit()


### PR DESCRIPTION
## Summary
- stop running local simulation in Game.gd
- emit `snapshot_applied` from Client.gd and refresh UI when snapshot arrives

## Testing
- `godot --headless --path . --check` *(fails: missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bcede616708328a7d2f52547896c5d