### PR TITLE
Ensure offline server registers local peers

### DIFF
--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -27,9 +27,12 @@ func _ready() -> void:
     timer.start()
 
 func _start_offline() -> void:
-    var peer := OfflineMultiplayerPeer.new()
+    var peer: OfflineMultiplayerPeer = OfflineMultiplayerPeer.new()
     peer.create_server(2)
+    peer.add_peer(2)
     multiplayer.multiplayer_peer = peer
+    var peers: Array[int] = multiplayer.get_peers()
+    assert(peers == [1, 2], "Expected peers [1, 2], got %s" % str(peers))
     world.register_player(1)
     world.register_player(2)
 


### PR DESCRIPTION
## Summary
- Ensure offline server explicitly adds peer 2 and verifies peer list

## Testing
- `godot --headless --path . --check` *(fails: No loader found for resource: res://assets/ui/window_frame_256.png)*

------
https://chatgpt.com/codex/tasks/task_e_68be1156586c8328ad6ac968c09ccd4d