### PR TITLE
Use length() when logging observation size

### DIFF
--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -106,7 +106,7 @@ func _make_locations_state() -> Dictionary:
     return data
 
 func _on_observation_ready(peer_id:int, obs:Dictionary) -> void:
-    var size := JSON.stringify(obs).length
+    var size := JSON.stringify(obs).length()
     var text := "Sending observation to peer {peer} ({size} bytes)".format({"peer": peer_id, "size": size})
     Logger.log("Server", text)
     rpc_id(peer_id, "push_observation", obs)


### PR DESCRIPTION
## Summary
- Fix observation payload size logging by calling `String.length()` instead of using `String.length` property

## Testing
- `godot --headless --path . --check` *(fails: Unable to load resources and missing RPC configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68be155bf2988328b7708446e8a0ebfe