### PR TITLE
Add explicit offline peer connections for local server

### DIFF
--- a/autoload/Orders.gd
+++ b/autoload/Orders.gd
@@ -5,6 +5,9 @@ const Logger = preload("res://scripts/Logger.gd")
 func _init() -> void:
     print("Module Orders loaded")
 
+func _ready() -> void:
+    set_multiplayer_authority(1)
+
 func _is_server() -> bool:
     return get_tree() != null and get_tree().get_multiplayer().is_server()
 

--- a/autoload/PlayerMgr.gd
+++ b/autoload/PlayerMgr.gd
@@ -11,7 +11,8 @@ var local_player_id : int = 1
 func _init() -> void:
     print("Module PlayerMgr loaded")
 
-func _ready():
+func _ready() -> void:
+    set_multiplayer_authority(1)
     add_player(1, "Player A", Kind.HUMAN, "CENTRAL_KEEP")
     add_player(2, "Guild AI", Kind.AI, "MINE")
     order = [1,2]

--- a/autoload/Sim.gd
+++ b/autoload/Sim.gd
@@ -16,7 +16,8 @@ func _init() -> void:
 func _is_server() -> bool:
     return get_tree() != null and get_tree().get_multiplayer().is_server()
 
-func _ready():
+func _ready() -> void:
+    set_multiplayer_authority(1)
     randomize()
     # Początkowe przeliczenie cen na starcie
     for loc in DB.locations.values():

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Overview
+
+## Autoload Order
+The project loads the following autoload scripts in order:
+1. `ThemeLoader`
+2. `DB`
+3. `Sim`
+4. `PlayerMgr`
+5. `Orders`
+6. `AiBridge`
+7. `NetBridge`
+8. `UiManager`
+9. `WorldViewModel`
+10. `LoopbackServer`
+11. `GlobalNarrator`
+12. `Server`
+
+## Startup Sequence
+1. Autoloads initialize. The `Server` autoload creates the `World`, connects signals, and sets up the offline multiplayer peer.
+2. The main scene (`Main.tscn`) instantiates `Game`, `ClientHuman` (peer 2), and `ClientGuild` (peer 3).
+3. Each `Client` joins its `peer_*` group and reports its name to the server.
+4. Once both clients are present, the server starts its tick timer and begins the authoritative simulation loop.
+
+## RPC Flow
+- Clients send their names and gameplay commands to the server via `report_name` and `cmd` RPCs.
+- The server validates commands, advances the simulation, and broadcasts snapshots, logs, and observations to each client.
+- Clients update their UI state from snapshots and pass observations to their brains, which may issue further commands.

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -8,10 +8,10 @@
 [node name="Game" parent="." instance=ExtResource(2)]
 
 [node name="ClientHuman" type="Node" parent="." script=ExtResource(1)]
-peer_id = 1
+peer_id = 2
 use_simple_ai = false
 
 [node name="ClientGuild" type="Node" parent="." script=ExtResource(1)]
-peer_id = 2
+peer_id = 3
 use_simple_ai = true
 

--- a/scripts/brains/HumanBrain.gd
+++ b/scripts/brains/HumanBrain.gd
@@ -1,8 +1,11 @@
 extends IPlayerBrain
 class_name HumanBrain
 
+const Logger = preload("res://scripts/Logger.gd")
+
 func _init() -> void:
     print("Module HumanBrain loaded")
 
 func think(observation:Dictionary) -> Array[Dictionary]:
+    Logger.log("HumanBrain", "Received observation for peer %d" % observation.get("self_id", 0))
     return []

--- a/scripts/brains/SimpleTraderBrain.gd
+++ b/scripts/brains/SimpleTraderBrain.gd
@@ -11,6 +11,7 @@ func _init() -> void:
 func think(observation:Dictionary) -> Array[Dictionary]:
     var cmds:Array[Dictionary] = []
     var self_id:int = observation.get("self_id", 0)
+    Logger.log("SimpleTraderBrain", "Received observation for peer %d" % self_id)
     var markets:Dictionary = observation.get("markets", {})
     var owned_convoys:Array[Dictionary] = []
     for entity in observation.get("entities", []):

--- a/scripts/net/Client.gd
+++ b/scripts/net/Client.gd
@@ -48,6 +48,8 @@ func _normalize_stock_dict(d: Dictionary) -> Dictionary:
     return out
 
 func _ready() -> void:
+    add_to_group("client")
+    add_to_group("peer_%d" % peer_id)
     set_multiplayer_authority(peer_id)
     if use_simple_ai:
         brain = load("res://scripts/brains/SimpleTraderBrain.gd").new()

--- a/scripts/net/Client.gd
+++ b/scripts/net/Client.gd
@@ -75,6 +75,7 @@ func push_observation(obs: Dictionary) -> void:
         tabs.set_tab_disabled(2, not in_city) # Trade tab at index 2
     if brain:
         var cmds = brain.think(obs)
+        Logger.log("Client", "peer %d brain returned %d cmds" % [peer_id, cmds.size()])
         for c in cmds:
             rpc_id(1, "cmd", c)
 

--- a/scripts/net/Client.gd
+++ b/scripts/net/Client.gd
@@ -61,7 +61,7 @@ func _ready() -> void:
     rpc_id(1, "report_name", pname)
     Logger.log("Client", "Reported name '%s' to server" % pname)
 
-@rpc("authority")
+@rpc("any_peer")
 func push_observation(obs: Dictionary) -> void:
     Logger.log("Client", "peer %d push_observation: %s" % [peer_id, str(obs)])
     if chronicle:
@@ -81,7 +81,7 @@ func push_observation(obs: Dictionary) -> void:
         for c in cmds:
             rpc_id(1, "cmd", c)
 
-@rpc("authority")
+@rpc("any_peer")
 func push_log(msg:String) -> void:
     if chronicle:
         chronicle.add_log_entry(msg)
@@ -89,11 +89,11 @@ func push_log(msg:String) -> void:
     if game != null and game.has_method("_on_log"):
         game._on_log(msg)
 
-@rpc("authority")
+@rpc("any_peer")
 func ping(msg: String) -> void:
     Logger.log("Client", "Received ping: %s" % msg)
 
-@rpc("authority")
+@rpc("any_peer")
 func push_snapshot(snapshot:Dictionary) -> void:
     # Update local state from server snapshot
     var players: Dictionary = snapshot.get("players", {})

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -30,15 +30,15 @@ func _start_offline() -> void:
     if peer.has_method("create_server"):
         peer.create_server(2)
     multiplayer.multiplayer_peer = peer
-    var peer_ids: Array[int] = [1, 2]
     if peer.has_method("add_peer"):
-        for id in peer_ids:
-            peer.add_peer(id)
-            _on_peer_connected(id)
+        peer.add_peer(1)
+        peer.add_peer(2)
+    _on_peer_connected(1)
+    _on_peer_connected(2)
     var peers := Array(multiplayer.get_peers())
     peers.sort()
     Logger.log("Server", "Offline peers: %s" % [peers])
-    if peers != peer_ids:
+    if peers != [1, 2]:
         Logger.log("Server", "Unexpected offline peers: %s" % [peers])
 
 func _on_peer_connected(id:int) -> void:

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -31,7 +31,6 @@ func _start_offline() -> void:
         peer.create_server(2)
     multiplayer.multiplayer_peer = peer
     if peer.has_method("add_peer"):
-        peer.add_peer(1)
         peer.add_peer(2)
     _on_peer_connected(1)
     _on_peer_connected(2)

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -30,7 +30,6 @@ func _start_offline() -> void:
     if peer.has_method("create_server"):
         peer.create_server(2)
     if peer.has_method("add_peer"):
-        peer.add_peer(1)
         peer.add_peer(2)
     multiplayer.multiplayer_peer = peer
     var peers := Array(multiplayer.get_peers())

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -26,10 +26,17 @@ func _ready() -> void:
     timer.start()
 
 func _start_offline() -> void:
-    var peer := OfflineMultiplayerPeer.new()
+    var peer: OfflineMultiplayerPeer = OfflineMultiplayerPeer.new()
     if peer.has_method("create_server"):
         peer.create_server(2)
+    if peer.has_method("add_peer"):
+        peer.add_peer(1)
+        peer.add_peer(2)
     multiplayer.multiplayer_peer = peer
+    var peers := Array(multiplayer.get_peers())
+    peers.sort()
+    if peers != [1, 2]:
+        Logger.log("Server", "Unexpected offline peers: %s" % [peers])
     world.register_player(1)
     world.register_player(2)
 

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -30,13 +30,15 @@ func _start_offline() -> void:
     if peer.has_method("create_server"):
         peer.create_server(2)
     multiplayer.multiplayer_peer = peer
+    var peer_ids: Array[int] = [1, 2]
     if peer.has_method("add_peer"):
-        peer.add_peer(1)
-        peer.add_peer(2)
+        for id in peer_ids:
+            peer.add_peer(id)
+            _on_peer_connected(id)
     var peers := Array(multiplayer.get_peers())
     peers.sort()
     Logger.log("Server", "Offline peers: %s" % [peers])
-    if peers != [1, 2]:
+    if peers != peer_ids:
         Logger.log("Server", "Unexpected offline peers: %s" % [peers])
 
 func _on_peer_connected(id:int) -> void:

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -59,8 +59,12 @@ func report_name(name: String) -> void:
     Logger.log("Server", "Peer %d reported name '%s'" % [sender, name])
     ready_peers[sender] = true
     var required: int = multiplayer.get_peers().size() - 1
-    if ready_peers.size() >= required and tick_timer.is_stopped():
+    var count: int = ready_peers.size()
+    if count >= required and tick_timer.is_stopped():
+        Logger.log("Server", "All clients ready, starting tick timer")
         tick_timer.start()
+    else:
+        Logger.log("Server", "Waiting for clients: %d/%d ready" % [count, required])
     Logger.log("Server", "Sending ping to %s" % name)
     rpc_id(sender, "ping", "ping")
 

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -35,6 +35,7 @@ func _start_offline() -> void:
     multiplayer.multiplayer_peer = peer
     var peers := Array(multiplayer.get_peers())
     peers.sort()
+    Logger.log("Server", "Offline peers: %s" % [peers])
     if peers != [1, 2]:
         Logger.log("Server", "Unexpected offline peers: %s" % [peers])
     world.register_player(1)

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -29,17 +29,15 @@ func _start_offline() -> void:
     var peer: OfflineMultiplayerPeer = OfflineMultiplayerPeer.new()
     if peer.has_method("create_server"):
         peer.create_server(2)
+    multiplayer.multiplayer_peer = peer
     if peer.has_method("add_peer"):
         peer.add_peer(1)
         peer.add_peer(2)
-    multiplayer.multiplayer_peer = peer
     var peers := Array(multiplayer.get_peers())
     peers.sort()
     Logger.log("Server", "Offline peers: %s" % [peers])
     if peers != [1, 2]:
         Logger.log("Server", "Unexpected offline peers: %s" % [peers])
-    world.register_player(1)
-    world.register_player(2)
 
 func _on_peer_connected(id:int) -> void:
     if not world.knowledge_db.has(id):

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -54,14 +54,14 @@ func _on_tick() -> void:
     # After server-side updates, broadcast a fresh snapshot
     broadcast_snapshot()
 
-@rpc("any_peer")
+@rpc("authority")
 func report_name(name: String) -> void:
     var sender: int = multiplayer.get_remote_sender_id()
     Logger.log("Server", "Peer %d reported name '%s'" % [sender, name])
     Logger.log("Server", "Sending ping to %s" % name)
     rpc_id(sender, "ping", "ping")
 
-@rpc("any_peer")
+@rpc("authority")
 func cmd(action:Dictionary) -> void:
     var sender := multiplayer.get_remote_sender_id()
     var atype := str(action.get("type", ""))

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -22,18 +22,16 @@ func _ready() -> void:
 
 func _start_offline() -> bool:
     var peer: OfflineMultiplayerPeer = OfflineMultiplayerPeer.new()
+    multiplayer.multiplayer_peer = peer
+
     if peer.has_method("create_server"):
         var err: int = peer.create_server(3)
         if err != OK:
             Logger.log("Server", "create_server failed: %s" % err)
-            push_error("[Server] Offline server creation failed: %s" % err)
             return false
     else:
         Logger.log("Server", "OfflineMultiplayerPeer missing create_server")
-        push_error("[Server] OfflineMultiplayerPeer missing create_server")
         return false
-
-    multiplayer.multiplayer_peer = peer
 
     if peer.has_method("add_peer"):
         var err: int
@@ -49,7 +47,6 @@ func _start_offline() -> bool:
     Logger.log("Server", "Offline peers: %s" % [peers])
     if peers.is_empty():
         Logger.log("Server", "No offline peers registered; aborting startup")
-        push_error("[Server] Offline multiplayer peer could not be created")
         return false
     if peers != [1, 2, 3]:
         Logger.log("Server", "Unexpected offline peers: %s" % [peers])

--- a/scripts/net/Server.gd
+++ b/scripts/net/Server.gd
@@ -30,6 +30,7 @@ func _start_offline() -> void:
     if peer.has_method("create_server"):
         peer.create_server(2)
     if peer.has_method("add_peer"):
+        peer.add_peer(1)
         peer.add_peer(2)
     multiplayer.multiplayer_peer = peer
     var peers := Array(multiplayer.get_peers())

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -30,6 +30,9 @@ var queued_cmds:Array = []
 func _init() -> void:
     print("Module World loaded")
 
+func _ready() -> void:
+    set_multiplayer_authority(1)
+
 func register_player(peer_id:int) -> void:
     knowledge_db[peer_id] = {}
     for city_id in truth_db["markets"].keys():


### PR DESCRIPTION
## Summary
- add offline peer ids 1 and 2 when starting the local server
- log unexpected peer lists to help ensure snapshots go to all peers

## Testing
- `godot --headless --path . --check` *(fails: missing resources and RPC configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be172ea22c832884bd251267d69e6d