### PR TITLE
Add map generation parameters to setup screen

### DIFF
--- a/game/map/MapGenerator.gd
+++ b/game/map/MapGenerator.gd
@@ -1,30 +1,43 @@
 extends RefCounted
 class_name MapGenerator
 
-var world_seed: int
+## Parameter container for map generation.
+class MapGenParams:
+    var seed: int
+    var node_count: int
+    var city_count: int
+    var max_river_count: int
+
+    func _init(seed: int = 0, node_count: int = 2, city_count: int = 3, max_river_count: int = 1) -> void:
+        self.seed = seed if seed != 0 else Time.get_ticks_msec()
+        self.node_count = node_count
+        self.city_count = city_count
+        self.max_river_count = max_river_count
+
+var params: MapGenParams
 var rng: RandomNumberGenerator
 
 const CityPlacerModule = preload("res://map/CityPlacer.gd")
 const RoadNetworkModule = preload("res://map/RoadNetwork.gd")
 const RiverGeneratorModule: Script = preload("res://map/RiverGenerator.gd")
 
-func _init(_seed: int) -> void:
-    world_seed = _seed
+func _init(_params: MapGenParams = MapGenParams.new()) -> void:
+    params = _params
     rng = RandomNumberGenerator.new()
-    rng.seed = world_seed
+    rng.seed = params.seed
 
 func generate() -> Dictionary:
     var map_data: Dictionary = {}
     var city_stage := CityPlacerModule.new(rng)
-    var cities := city_stage.place_cities()
+    var cities := city_stage.place_cities(params.city_count)
     map_data["cities"] = cities
 
     var road_stage := RoadNetworkModule.new(rng)
-    var roads := road_stage.build_roads(cities)
+    var roads := road_stage.build_roads(cities, params.node_count)
     map_data["roads"] = roads
 
     var river_stage: RiverGenerator = RiverGeneratorModule.new(rng)
-    var rivers: Array = river_stage.generate_rivers(roads)
+    var rivers: Array = river_stage.generate_rivers(roads, params.max_river_count)
     map_data["rivers"] = rivers
 
     return map_data

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -3,6 +3,10 @@ extends Control
 const MapGeneratorModule = preload("res://map/MapGenerator.gd")
 
 @onready var title_label: Label = $VBox/Title
+@onready var seed_spin: SpinBox = $VBox/Params/Seed
+@onready var nodes_spin: SpinBox = $VBox/Params/Nodes
+@onready var cities_spin: SpinBox = $VBox/Params/Cities
+@onready var rivers_spin: SpinBox = $VBox/Params/Rivers
 @onready var map_view: MapView = $VBox/MapView
 @onready var generate_button: Button = $VBox/Buttons/Generate
 @onready var start_button: Button = $VBox/Buttons/Start
@@ -20,6 +24,10 @@ func _ready() -> void:
     generate_button.pressed.connect(_on_generate_pressed)
     start_button.pressed.connect(_on_start_pressed)
     back_button.pressed.connect(_on_back_pressed)
+    seed_spin.value_changed.connect(_on_params_changed)
+    nodes_spin.value_changed.connect(_on_params_changed)
+    cities_spin.value_changed.connect(_on_params_changed)
+    rivers_spin.value_changed.connect(_on_params_changed)
     _update_texts()
     _generate_map()
     _on_net_state_changed(Net.state)
@@ -31,12 +39,24 @@ func _update_texts() -> void:
     back_button.text = I18N.t("menu.back")
 
 func _generate_map() -> void:
-    var map_seed: int = Time.get_ticks_msec()
-    var generator := MapGeneratorModule.new(map_seed)
+    var params := MapGeneratorModule.MapGenParams.new(
+        int(seed_spin.value),
+        int(nodes_spin.value),
+        int(cities_spin.value),
+        int(rivers_spin.value)
+    )
+    if seed_spin.value != params.seed:
+        seed_spin.set_block_signals(true)
+        seed_spin.value = params.seed
+        seed_spin.set_block_signals(false)
+    var generator := MapGeneratorModule.new(params)
     current_map = generator.generate()
     map_view.set_map_data(current_map)
 
 func _on_generate_pressed() -> void:
+    _generate_map()
+
+func _on_params_changed(_value: float) -> void:
     _generate_map()
 
 func _on_start_pressed() -> void:

--- a/game/ui/MapSetupScreen.tscn
+++ b/game/ui/MapSetupScreen.tscn
@@ -16,6 +16,44 @@ size_flags_vertical = 3
 
 [node name="Title" type="Label" parent="VBox"]
 
+[node name="Params" type="GridContainer" parent="VBox"]
+columns = 2
+
+[node name="SeedLabel" type="Label" parent="VBox/Params"]
+text = "Seed"
+
+[node name="Seed" type="SpinBox" parent="VBox/Params"]
+min_value = 0.0
+max_value = 1.0e+09
+step = 1.0
+
+[node name="NodesLabel" type="Label" parent="VBox/Params"]
+text = "Nodes"
+
+[node name="Nodes" type="SpinBox" parent="VBox/Params"]
+min_value = 1.0
+max_value = 10.0
+step = 1.0
+value = 2.0
+
+[node name="CitiesLabel" type="Label" parent="VBox/Params"]
+text = "Cities"
+
+[node name="Cities" type="SpinBox" parent="VBox/Params"]
+min_value = 1.0
+max_value = 20.0
+step = 1.0
+value = 3.0
+
+[node name="RiversLabel" type="Label" parent="VBox/Params"]
+text = "Rivers"
+
+[node name="Rivers" type="SpinBox" parent="VBox/Params"]
+min_value = 0.0
+max_value = 10.0
+step = 1.0
+value = 1.0
+
 [node name="MapView" type="Control" parent="VBox"]
 custom_minimum_size = Vector2(400, 300)
 size_flags_horizontal = 3


### PR DESCRIPTION
## Summary
- Allow tweaking seed, node count, city count and river count when generating maps
- Centralize map generation settings in `MapGenParams`
- Auto-refresh map preview when parameters change or Generate is pressed

## Testing
- `godot --headless --path game --quit`


------
https://chatgpt.com/codex/tasks/task_e_68c0572d43848328bf79f065dea3faa3