### PR TITLE
docs: document map setup preview flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.12 — 2025-09-09
+Added
+- Documented map setup preview flow and manual test checklist.
+
 0.1.11 — 2025-09-08
 Added
 - Map setup screen to preview generated maps and handle start flow.

--- a/docs/checks/Map_Setup_Checklist.md
+++ b/docs/checks/Map_Setup_Checklist.md
@@ -1,0 +1,14 @@
+Map Setup Checklist
+
+- Parameter adjustment:
+    - Modify map parameters (size, seed).
+    - Preview updates immediately.
+- Identical seed:
+    - Set the same seed twice.
+    - Previewed maps are identical.
+- Start:
+    - Press Start.
+    - Game launches with the previewed map.
+- Back:
+    - Press Back.
+    - Returns to the menu.

--- a/docs/phases/PHASE-02_Run_Modes.md
+++ b/docs/phases/PHASE-02_Run_Modes.md
@@ -5,10 +5,11 @@ Cel:
 
 Maszyna stanów (tablica):
 - MENU — wejście: uruchomienie aplikacji; wyjście: wybór Single/Host/Join.  
-- CONNECTING.starting_host — tworzenie hosta (lokalnie lub sieciowo).  
-- CONNECTING.joining_host — łączenie do hosta.  
-- CONNECTING.retrying — ponawianie prób po błędzie.  
-- READY — po udanym połączeniu: załaduj scenę Game.  
+- CONNECTING.starting_host — tworzenie hosta (lokalnie lub sieciowo).
+- CONNECTING.joining_host — łączenie do hosta.
+- CONNECTING.retrying — ponawianie prób po błędzie.
+- MAP_SETUP.preview — po udanym połączeniu generuj mapę i pokazuj jej podgląd; Start przechodzi do READY, Back wraca do MENU.
+- READY — po naciśnięciu Start w podglądzie: załaduj scenę Game.
 - GAME — rozgrywka; z tego stanu można przejść do PAUSED lub z powrotem do MENU.  
 - FAILED — panel błędu z opcjami Retry/Back.
 
@@ -18,9 +19,10 @@ Parametry techniczne (opisowo):
 - Komunikaty błędów muszą używać kluczy `errors.*` i zawierać przycisk „Retry”.
 
 Checklist testów ręcznych:
-- Single Player: wybór powoduje „starting_host” → „ready” → wejście do Game.  
-- Multiplayer Host: wybór powoduje „starting_host”; pokazuje stan hostowania; Join wyświetla formularz adresu/kodu (placeholder w tej fazie).  
+- Single Player: wybór powoduje „starting_host” → podgląd mapy → „ready” → wejście do Game.
+- Multiplayer Host: wybór powoduje „starting_host”; pokazuje stan hostowania; Join wyświetla formularz adresu/kodu (placeholder w tej fazie).
 - Multiplayer Join: wejście do formularza; próba z nieprawidłowym adresem pokazuje `errors.invalid_address`.
+- Map Setup: zmiana parametrów wpływa na podgląd; Start uruchamia grę z tą mapą; Back wraca do MENU.
 
 Definition of Done:
 - Dokumentacja kompletna; przypadki błędów i retry opisane; i18n klucze uwzględnione.

--- a/docs/phases/PHASE-03_Map.md
+++ b/docs/phases/PHASE-03_Map.md
@@ -3,6 +3,11 @@ PHASE‑03 — Map (vector; seeded; validations)
 Cel:
 - Opisać deterministyczny pipeline generacji wektorowej mapy wraz z walidacjami i modelem danych.
 
+Map-setup flow:
+- Podgląd mapy pojawia się przed stanami READY i GAME.
+- Zmiana parametrów (seed, rozmiar itp.) natychmiast aktualizuje podgląd.
+- **Start** zatwierdza mapę i przechodzi do gry; **Back** wraca do MENU.
+
 Pipeline szczegółowy:
 1) Rozmieszczenie miast: rozstaw punkty zgodnie z „blue‑noise” (np. Poisson‑like) z minimalną odległością między miastami.  
 2) Połączenia główne: oblicz połączenia kandydujące (np. triangulacja/Delaunay), zredukuj do MST dla spójności, następnie dodaj k‑najbliższych sąsiadów dla alternatyw (k=1..2).  
@@ -13,7 +18,7 @@ Pipeline szczegółowy:
 7) Walidacje: spójność grafu dróg, brak krawędzi „wiszących”, rzeki nie tną dróg bez węzła mostu/brodu, stabilne ID.
 
 Implementacja walidacji: `game/map/MapValidator.gd`.
-Manualne testy: `docs/checks/Map_Generation_Checklist.md`.
+Manualne testy: `docs/checks/Map_Generation_Checklist.md` oraz `docs/checks/Map_Setup_Checklist.md`.
 
 Model danych — patrz `docs/specs/Map_Data_Model.md`.
 


### PR DESCRIPTION
## Summary
- document map setup preview in run modes and map phase docs
- add map setup manual test checklist
- record map setup docs in changelog

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c06976dc5c832884d24c6f81cac27a