### PR TITLE
feat: localize map setup parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.13 — 2025-09-09
+Added
+- Localized map setup parameter labels for seed, nodes, cities and rivers, removing hardcoded text.
+
 0.1.12 — 2025-09-09
 Added
 - Documented map setup preview flow and manual test checklist.

--- a/docs/i18n/Strings_Catalog_P3_MapSetup.md
+++ b/docs/i18n/Strings_Catalog_P3_MapSetup.md
@@ -7,3 +7,7 @@ Namespace `setup.*`
 | setup.title   | Map Setup   | Ustawienia mapy  | screen title |
 | setup.generate| Generate    | Generuj          | regenerate map |
 | setup.start   | Start       | Start            | begin game |
+| setup.seed    | Seed        | Ziarno           | random seed |
+| setup.nodes   | Nodes       | Węzły            | number of nodes |
+| setup.cities  | Cities      | Miasta           | number of cities |
+| setup.rivers  | Rivers      | Rzeki            | number of rivers |

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -3,9 +3,13 @@ extends Control
 const MapGeneratorModule = preload("res://map/MapGenerator.gd")
 
 @onready var title_label: Label = $VBox/Title
+@onready var seed_label: Label = $VBox/Params/SeedLabel
 @onready var seed_spin: SpinBox = $VBox/Params/Seed
+@onready var nodes_label: Label = $VBox/Params/NodesLabel
 @onready var nodes_spin: SpinBox = $VBox/Params/Nodes
+@onready var cities_label: Label = $VBox/Params/CitiesLabel
 @onready var cities_spin: SpinBox = $VBox/Params/Cities
+@onready var rivers_label: Label = $VBox/Params/RiversLabel
 @onready var rivers_spin: SpinBox = $VBox/Params/Rivers
 @onready var map_view: MapView = $VBox/MapView
 @onready var generate_button: Button = $VBox/Buttons/Generate
@@ -34,6 +38,10 @@ func _ready() -> void:
 
 func _update_texts() -> void:
     title_label.text = I18N.t("setup.title")
+    seed_label.text = I18N.t("setup.seed")
+    nodes_label.text = I18N.t("setup.nodes")
+    cities_label.text = I18N.t("setup.cities")
+    rivers_label.text = I18N.t("setup.rivers")
     generate_button.text = I18N.t("setup.generate")
     start_button.text = I18N.t("setup.start")
     back_button.text = I18N.t("menu.back")

--- a/game/ui/MapSetupScreen.tscn
+++ b/game/ui/MapSetupScreen.tscn
@@ -20,7 +20,6 @@ size_flags_vertical = 3
 columns = 2
 
 [node name="SeedLabel" type="Label" parent="VBox/Params"]
-text = "Seed"
 
 [node name="Seed" type="SpinBox" parent="VBox/Params"]
 min_value = 0.0
@@ -28,7 +27,6 @@ max_value = 1.0e+09
 step = 1.0
 
 [node name="NodesLabel" type="Label" parent="VBox/Params"]
-text = "Nodes"
 
 [node name="Nodes" type="SpinBox" parent="VBox/Params"]
 min_value = 1.0
@@ -37,7 +35,6 @@ step = 1.0
 value = 2.0
 
 [node name="CitiesLabel" type="Label" parent="VBox/Params"]
-text = "Cities"
 
 [node name="Cities" type="SpinBox" parent="VBox/Params"]
 min_value = 1.0
@@ -46,7 +43,6 @@ step = 1.0
 value = 3.0
 
 [node name="RiversLabel" type="Label" parent="VBox/Params"]
-text = "Rivers"
 
 [node name="Rivers" type="SpinBox" parent="VBox/Params"]
 min_value = 0.0


### PR DESCRIPTION
## Summary
- add i18n keys for map setup parameter labels
- wire map setup labels to localized strings
- remove hardcoded map setup label text

## Testing
- `bash tools/check.sh` *(fails: hangs after Godot output)*
- `bash tools/check.sh . quick`


------
https://chatgpt.com/codex/tasks/task_e_68c06f2f6f988328b4edc5eb780e4e9e