### PR TITLE
feat: add random seed button to map setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.14 — 2025-09-09
+Added
+- Random seed button in map setup screen replacing generate button.
+
 0.1.13 — 2025-09-09
 Added
 - Localized map setup parameter labels for seed, nodes, cities and rivers, removing hardcoded text.

--- a/docs/i18n/Strings_Catalog_P3_MapSetup.md
+++ b/docs/i18n/Strings_Catalog_P3_MapSetup.md
@@ -5,7 +5,7 @@ Namespace `setup.*`
 | key           | en          | pl               | note |
 |---------------|-------------|------------------|------|
 | setup.title   | Map Setup   | Ustawienia mapy  | screen title |
-| setup.generate| Generate    | Generuj          | regenerate map |
+| setup.random_seed | Random Seed | Losowe ziarno | assign random seed |
 | setup.start   | Start       | Start            | begin game |
 | setup.seed    | Seed        | Ziarno           | random seed |
 | setup.nodes   | Nodes       | Węzły            | number of nodes |

--- a/game/i18n/en.cfg
+++ b/game/i18n/en.cfg
@@ -34,7 +34,11 @@ roles.observer="Observer"
 roles.admin="Admin"
 
 setup.title="Map Setup"
-setup.generate="Generate"
+setup.seed="Seed"
+setup.random_seed="Random Seed"
+setup.nodes="Nodes"
+setup.cities="Cities"
+setup.rivers="Rivers"
 setup.start="Start"
 
 errors.timeout="Connection timeout"

--- a/game/i18n/pl.cfg
+++ b/game/i18n/pl.cfg
@@ -34,7 +34,11 @@ roles.observer="Obserwator"
 roles.admin="Administrator"
 
 setup.title="Ustawienia mapy"
-setup.generate="Generuj"
+setup.seed="Ziarno"
+setup.random_seed="Losowe ziarno"
+setup.nodes="Węzły"
+setup.cities="Miasta"
+setup.rivers="Rzeki"
 setup.start="Start"
 
 errors.timeout="Przekroczono czas oczekiwania"

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -4,7 +4,8 @@ const MapGeneratorModule = preload("res://map/MapGenerator.gd")
 
 @onready var title_label: Label = $VBox/Title
 @onready var seed_label: Label = $VBox/Params/SeedLabel
-@onready var seed_spin: SpinBox = $VBox/Params/Seed
+@onready var seed_spin: SpinBox = $VBox/Params/SeedRow/Seed
+@onready var random_seed_button: Button = $VBox/Params/SeedRow/RandomSeed
 @onready var nodes_label: Label = $VBox/Params/NodesLabel
 @onready var nodes_spin: SpinBox = $VBox/Params/Nodes
 @onready var cities_label: Label = $VBox/Params/CitiesLabel
@@ -12,7 +13,6 @@ const MapGeneratorModule = preload("res://map/MapGenerator.gd")
 @onready var rivers_label: Label = $VBox/Params/RiversLabel
 @onready var rivers_spin: SpinBox = $VBox/Params/Rivers
 @onready var map_view: MapView = $VBox/MapView
-@onready var generate_button: Button = $VBox/Buttons/Generate
 @onready var start_button: Button = $VBox/Buttons/Start
 @onready var back_button: Button = $VBox/Buttons/Back
 @onready var main_ui: VBoxContainer = $VBox
@@ -25,7 +25,7 @@ func _ready() -> void:
     I18N.language_changed.connect(_update_texts)
     Net.state_changed.connect(_on_net_state_changed)
     add_child(connecting_ui)
-    generate_button.pressed.connect(_on_generate_pressed)
+    random_seed_button.pressed.connect(_on_random_seed_pressed)
     start_button.pressed.connect(_on_start_pressed)
     back_button.pressed.connect(_on_back_pressed)
     seed_spin.value_changed.connect(_on_params_changed)
@@ -39,10 +39,10 @@ func _ready() -> void:
 func _update_texts() -> void:
     title_label.text = I18N.t("setup.title")
     seed_label.text = I18N.t("setup.seed")
+    random_seed_button.text = I18N.t("setup.random_seed")
     nodes_label.text = I18N.t("setup.nodes")
     cities_label.text = I18N.t("setup.cities")
     rivers_label.text = I18N.t("setup.rivers")
-    generate_button.text = I18N.t("setup.generate")
     start_button.text = I18N.t("setup.start")
     back_button.text = I18N.t("menu.back")
 
@@ -61,10 +61,14 @@ func _generate_map() -> void:
     current_map = generator.generate()
     map_view.set_map_data(current_map)
 
-func _on_generate_pressed() -> void:
+func _on_params_changed(_value: float) -> void:
     _generate_map()
 
-func _on_params_changed(_value: float) -> void:
+func _on_random_seed_pressed() -> void:
+    seed_spin.set_block_signals(true)
+    var random_value: int = randi() % int(seed_spin.max_value)
+    seed_spin.value = random_value
+    seed_spin.set_block_signals(false)
     _generate_map()
 
 func _on_start_pressed() -> void:

--- a/game/ui/MapSetupScreen.tscn
+++ b/game/ui/MapSetupScreen.tscn
@@ -21,10 +21,14 @@ columns = 2
 
 [node name="SeedLabel" type="Label" parent="VBox/Params"]
 
-[node name="Seed" type="SpinBox" parent="VBox/Params"]
+[node name="SeedRow" type="HBoxContainer" parent="VBox/Params"]
+
+[node name="Seed" type="SpinBox" parent="VBox/Params/SeedRow"]
 min_value = 0.0
 max_value = 1.0e+09
 step = 1.0
+
+[node name="RandomSeed" type="Button" parent="VBox/Params/SeedRow"]
 
 [node name="NodesLabel" type="Label" parent="VBox/Params"]
 
@@ -58,8 +62,6 @@ script = ExtResource(2)
 
 [node name="Buttons" type="HBoxContainer" parent="VBox"]
 size_flags_horizontal = 3
-
-[node name="Generate" type="Button" parent="VBox/Buttons"]
 
 [node name="Start" type="Button" parent="VBox/Buttons"]
 


### PR DESCRIPTION
## Summary
- add random-seed button next to seed input and remove generate button
- wire up random seed handler and localization keys
- document new i18n key and bump changelog

## Testing
- `bash tools/check.sh` *(fails: hangs after Godot engine banner)*

------
https://chatgpt.com/codex/tasks/task_e_68c071df0e908328895af5c9fc06bf40