### PR TITLE
feat: vary road connections per city

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.16 — 2025-09-09
+Added
+- Variable road connections per city supporting min/max connection bounds.
+
 0.1.15 — 2025-09-09
 Added
 - Mouse wheel zoom and drag panning in map view with configurable limits.

--- a/game/map/MapGenerator.gd
+++ b/game/map/MapGenerator.gd
@@ -44,7 +44,7 @@ func generate() -> Dictionary:
     map_data["cities"] = cities
 
     var road_stage := RoadNetworkModule.new(rng)
-    var roads := road_stage.build_roads(cities, params.node_count)
+    var roads := road_stage.build_roads(cities, params.min_connections, params.max_connections)
     map_data["roads"] = roads
 
     var river_stage: RiverGenerator = RiverGeneratorModule.new(rng)


### PR DESCRIPTION
## Summary
- allow road generation to choose city-specific connection counts within a min/max range
- pass new min/max connection parameters from map generator
- document variable road connectivity in changelog

## Testing
- `godot --headless --path game --quit-after 1`
- `godot --headless --check-only --path game --script map/MapGenerator.gd` *(fails: Could not find type "RiverGenerator" in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c084e468fc83289cceed70392b48a4