### PR TITLE
Add Voronoi-based region generation

### DIFF
--- a/game/map/MapGenerator.gd
+++ b/game/map/MapGenerator.gd
@@ -28,6 +28,7 @@ var rng: RandomNumberGenerator
 const CityPlacerModule = preload("res://map/CityPlacer.gd")
 const RoadNetworkModule = preload("res://map/RoadNetwork.gd")
 const RiverGeneratorModule: Script = preload("res://map/RiverGenerator.gd")
+const RegionGeneratorModule: Script = preload("res://map/RegionGenerator.gd")
 
 func _init(_params: MapGenParams = MapGenParams.new()) -> void:
     params = _params
@@ -40,11 +41,15 @@ func generate() -> Dictionary:
     var cities := city_stage.place_cities(params.city_count)
     map_data["cities"] = cities
 
+    var region_stage = RegionGeneratorModule.new()
+    var regions: Dictionary = region_stage.generate_regions(cities)
+    map_data["regions"] = regions
+
     var road_stage := RoadNetworkModule.new(rng)
     var roads := road_stage.build_roads(cities, params.min_connections, params.max_connections)
     map_data["roads"] = roads
 
-    var river_stage: RiverGenerator = RiverGeneratorModule.new(rng)
+    var river_stage = RiverGeneratorModule.new(rng)
     var rivers: Array = river_stage.generate_rivers(roads, params.max_river_count)
     map_data["rivers"] = rivers
 

--- a/game/map/Region.gd
+++ b/game/map/Region.gd
@@ -2,7 +2,8 @@ extends RefCounted
 class_name Region
 
 var id: int
-var boundary_nodes: Array[int]
+# Boundary of the region represented as a list of Vector2 points.
+var boundary_nodes: Array[Vector2]
 var narrator: String
 
 func _init(_id: int, _boundary_nodes: Array = [], _narrator: String = "") -> void:
@@ -11,8 +12,11 @@ func _init(_id: int, _boundary_nodes: Array = [], _narrator: String = "") -> voi
     narrator = _narrator
 
 func to_dict() -> Dictionary:
+    var pts: Array = []
+    for p in boundary_nodes:
+        pts.append([p.x, p.y])
     return {
         "id": id,
-        "boundary_nodes": boundary_nodes,
+        "boundary_nodes": pts,
         "narrator": narrator,
     }

--- a/game/map/RegionGenerator.gd
+++ b/game/map/RegionGenerator.gd
@@ -1,0 +1,54 @@
+extends RefCounted
+class_name RegionGenerator
+
+const CityPlacerModule = preload("res://map/CityPlacer.gd")
+const RegionModule = preload("res://map/Region.gd")
+
+# Generates regions as Voronoi cells around city positions.
+# Returns a dictionary mapping region id -> Region instance.
+func generate_regions(cities: Array[Vector2]) -> Dictionary:
+    var regions: Dictionary = {}
+    for i in range(cities.size()):
+        var polygon: Array[Vector2] = _voronoi_cell(cities, i)
+        regions[i + 1] = RegionModule.new(i + 1, polygon, "")
+    return regions
+
+func _voronoi_cell(points: Array[Vector2], index: int) -> Array[Vector2]:
+    var bounds: Array[Vector2] = [
+        Vector2(0, 0),
+        Vector2(CityPlacerModule.WIDTH, 0),
+        Vector2(CityPlacerModule.WIDTH, CityPlacerModule.HEIGHT),
+        Vector2(0, CityPlacerModule.HEIGHT),
+    ]
+    var cell: Array[Vector2] = bounds.duplicate()
+    var p: Vector2 = points[index]
+    for j in range(points.size()):
+        if j == index:
+            continue
+        var q: Vector2 = points[j]
+        cell = _clip_cell(cell, p, q)
+    return cell
+
+# Clips polygon 'poly' by the half-plane of perpendicular bisector between p and q.
+func _clip_cell(poly: Array[Vector2], p: Vector2, q: Vector2) -> Array[Vector2]:
+    if poly.is_empty():
+        return []
+    var result: Array[Vector2] = []
+    var mid: Vector2 = (p + q) * 0.5
+    var dir: Vector2 = (q - p).normalized()
+    var normal: Vector2 = Vector2(dir.y, -dir.x)
+    # ensure normal points toward p side
+    if (p - mid).dot(normal) < 0:
+        normal = -normal
+    for i in range(poly.size()):
+        var a: Vector2 = poly[i]
+        var b: Vector2 = poly[(i + 1) % poly.size()]
+        var da: float = (a - mid).dot(normal)
+        var db: float = (b - mid).dot(normal)
+        if da >= 0:
+            result.append(a)
+        if da * db < 0:
+            var t: float = da / (da - db)
+            var intersection: Vector2 = a + (b - a) * t
+            result.append(intersection)
+    return result


### PR DESCRIPTION
## Summary
- compute Voronoi cells for city placement via new RegionGenerator
- store region boundaries and narrator placeholders using Region
- integrate regions into map generation pipeline

## Testing
- `bash tools/check.sh game`

------
https://chatgpt.com/codex/tasks/task_e_68c0a0754ea48328b27cb2ea35b44d3a