### PR TITLE
feat: add regions visibility toggle to map setup screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.18 — 2025-09-09
+Added
+- Toggle to show or hide regions in map setup screen.
+
 0.1.17 — 2025-09-09
 Removed
 - Map node count parameter and UI from map setup.

--- a/docs/i18n/Strings_Catalog_P3_MapSetup.md
+++ b/docs/i18n/Strings_Catalog_P3_MapSetup.md
@@ -12,3 +12,4 @@ Namespace `setup.*`
 | setup.rivers  | Rivers      | Rzeki            | number of rivers |
 | setup.min_connections | Min Connections | Min. połączeń | minimum road connections |
 | setup.max_connections | Max Connections | Maks. połączeń | maximum road connections |
+| setup.show_regions | Show Regions | Pokaż regiony | toggle region overlay |

--- a/game/i18n/en.cfg
+++ b/game/i18n/en.cfg
@@ -44,6 +44,7 @@ setup.show_roads="Show Roads"
 setup.show_rivers="Show Rivers"
 setup.show_cities="Show Cities"
 setup.show_crossings="Show Crossings"
+setup.show_regions="Show Regions"
 setup.start="Start"
 
 errors.timeout="Connection timeout"

--- a/game/i18n/pl.cfg
+++ b/game/i18n/pl.cfg
@@ -44,6 +44,7 @@ setup.show_roads="Pokaż drogi"
 setup.show_rivers="Pokaż rzeki"
 setup.show_cities="Pokaż miasta"
 setup.show_crossings="Pokaż skrzyżowania"
+setup.show_regions="Pokaż regiony"
 setup.start="Start"
 
 errors.timeout="Przekroczono czas oczekiwania"

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -19,6 +19,7 @@ const MapGeneratorModule = preload("res://map/MapGenerator.gd")
 @onready var show_rivers_check: CheckBox = $VBox/Layers/ShowRivers
 @onready var show_cities_check: CheckBox = $VBox/Layers/ShowCities
 @onready var show_crossings_check: CheckBox = $VBox/Layers/ShowCrossings
+@onready var show_regions_check: CheckBox = $VBox/Layers/ShowRegions
 @onready var start_button: Button = $VBox/Buttons/Start
 @onready var back_button: Button = $VBox/Buttons/Back
 @onready var main_ui: VBoxContainer = $VBox
@@ -49,10 +50,12 @@ func _ready() -> void:
     show_rivers_check.toggled.connect(_on_show_rivers_toggled)
     show_cities_check.toggled.connect(_on_show_cities_toggled)
     show_crossings_check.toggled.connect(_on_show_crossings_toggled)
+    show_regions_check.toggled.connect(_on_show_regions_toggled)
     map_view.set_show_roads(show_roads_check.button_pressed)
     map_view.set_show_rivers(show_rivers_check.button_pressed)
     map_view.set_show_cities(show_cities_check.button_pressed)
     map_view.set_show_crossings(show_crossings_check.button_pressed)
+    map_view.set_show_regions(show_regions_check.button_pressed)
     _update_texts()
     _generate_map()
     _on_net_state_changed(Net.state)
@@ -69,6 +72,7 @@ func _update_texts() -> void:
     show_rivers_check.text = I18N.t("setup.show_rivers")
     show_cities_check.text = I18N.t("setup.show_cities")
     show_crossings_check.text = I18N.t("setup.show_crossings")
+    show_regions_check.text = I18N.t("setup.show_regions")
     start_button.text = I18N.t("setup.start")
     back_button.text = I18N.t("menu.back")
 
@@ -106,6 +110,9 @@ func _on_show_cities_toggled(pressed: bool) -> void:
 
 func _on_show_crossings_toggled(pressed: bool) -> void:
     map_view.set_show_crossings(pressed)
+
+func _on_show_regions_toggled(pressed: bool) -> void:
+    map_view.set_show_regions(pressed)
 
 func _on_random_seed_pressed() -> void:
     seed_spin.set_block_signals(true)

--- a/game/ui/MapSetupScreen.tscn
+++ b/game/ui/MapSetupScreen.tscn
@@ -83,6 +83,9 @@ button_pressed = true
 [node name="ShowCrossings" type="CheckBox" parent="VBox/Layers"]
 button_pressed = false
 
+[node name="ShowRegions" type="CheckBox" parent="VBox/Layers"]
+button_pressed = true
+
 [node name="Buttons" type="HBoxContainer" parent="VBox"]
 size_flags_horizontal = 3
 


### PR DESCRIPTION
## Summary
- add Show Regions checkbox to map setup screen and wire to map view
- localize show regions label and document new string

## Testing
- `bash tools/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0a5a179988328a85b1d141cf82c26