### PR TITLE
docs: expand game design loops with kingdom mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.19 — 2025-09-09
+Added
+- Expanded game design doc with kingdom mechanics and region generation workflow.
+
 0.1.18 — 2025-09-09
 Added
 - Toggle to show or hide regions in map setup screen.

--- a/docs/design/Game_Design_and_Loops.md
+++ b/docs/design/Game_Design_and_Loops.md
@@ -3,12 +3,65 @@ Game Design & Loops
 Temat:
 - Handel i logistyka na grafie wektorowym (węzły i krawędzie).
 
-Pętle MVP:
-- Wybór trybu (Single/Host/Join) → ewentualny wybór roli/regionu → snapshot → eksploracja mapy → log zdarzeń.
+## Konfiguracja Królestw
+- Liczba królestw, kolory i miasta startowe definiują układ polityczny mapy.
+- Regiony są przydzielane kolejno tak, by każde królestwo zachowało ciągłość terytorialną.
+- Parametry konfiguracji są ustawiane przed generacją mapy.
 
-Rozszerzenia:
+## Ciągłość Regionów
+Podczas przydziału nowych regionów algorytm wybiera tylko pola sąsiadujące
+z już posiadanymi.
+
+```mermaid
+flowchart LR
+    U[Regiony nieprzydzielone] --> S[Startowe regiony]
+    S --> C{Sąsiad?}
+    C -- tak --> A[Dodaj do królestwa]
+    C -- nie --> F[Wyszukaj innego sąsiada]
+    F --> C
+    A --> S
+```
+
+## Przebieg Generacji Regionów
+1. Losowe punkty startowe tworzą diagram Voronoi.
+2. Powstałe komórki zamieniane są na wielokąty i sortowane po powierzchni.
+3. Obsługiwane są przypadki brzegowe: granice mapy, małe komórki, przebiegi rzek.
+
+```mermaid
+flowchart TD
+    A[Punkty startowe] --> B[Voronoi]
+    B --> C[Sortowanie wielokątów]
+    C --> D{Przypadek brzegowy?}
+    D -- granica --> E[Przytnij]
+    D -- mała komórka --> F[Scal]
+    D -- rzeka --> G[Koryguj]
+    D -- nie --> H[Finalizuj]
+    E --> H
+    F --> H
+    G --> H
+```
+
+## Pętla Rozgrywki
+- Wybór trybu (Single/Host/Join).
+- Przydział regionów do królestw.
+- Eksploracja mapy.
+- Log zdarzeń.
+
+```mermaid
+flowchart LR
+    M[Wybór trybu] --> R[Przydział regionów]
+    R --> E[Eksploracja]
+    E --> L[Log zdarzeń]
+    L --> M
+```
+
+## Implementacja
+- Szczegóły generacji mapy: [MapGenerator.gd](../../game/map/MapGenerator.gd).
+- Przydział i kształt regionów: [RegionGenerator.gd](../../game/map/RegionGenerator.gd).
+
+## Rozszerzenia
 - Wyznaczanie tras, czasy przejazdu, blokady mostów, proste cele dostawy A→B.
 
-UI — high‑level:
-- Ekran mapy: pełnoekranowa mapa, panel boczny z filtrami, pasek statusu (rola/region/seed/latency), log zdarzeń.  
+## UI — high‑level
+- Ekran mapy: pełnoekranowa mapa, panel boczny z filtrami, pasek statusu (rola/region/seed/latency), log zdarzeń.
 - Debug UI: peery, regiony, komendy, timeline snapshot/diff.


### PR DESCRIPTION
## Summary
- expand game design doc with kingdom configuration and contiguous region assignment
- document region generation workflow with Voronoi and edge cases
- clarify core gameplay loop and link to map generation code

## Testing
- `bash tools/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0a9ea0a20832897fb7c0874e6484a