### PR TITLE
feat: allocate contiguous kingdoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.23 — 2025-09-10
+Added
+- Configurable kingdom count with contiguous allocation and kingdom-aware region rendering.
+
 0.1.22 — 2025-09-10
 Fixed
 - Corrected Voronoi half-plane clipping so region edges fall midway between cities without overlapping.

--- a/game/map/MapGenerator.gd
+++ b/game/map/MapGenerator.gd
@@ -9,6 +9,7 @@ class MapGenParams:
     var min_connections: int
     var max_connections: int
     var crossing_detour_margin: float
+    var kingdom_count: int
 
     func _init(
         p_rng_seed: int = 0,
@@ -16,7 +17,8 @@ class MapGenParams:
         p_max_river_count: int = 1,
         p_min_connections: int = 1,
         p_max_connections: int = 3,
-        p_crossing_detour_margin: float = 5.0
+        p_crossing_detour_margin: float = 5.0,
+        p_kingdom_count: int = 1
     ) -> void:
         rng_seed = p_rng_seed if p_rng_seed != 0 else Time.get_ticks_msec()
         city_count = p_city_count
@@ -25,6 +27,7 @@ class MapGenParams:
         min_connections = clamp(p_min_connections, 1, max_possible)
         max_connections = clamp(p_max_connections, min_connections, max_possible)
         crossing_detour_margin = p_crossing_detour_margin
+        kingdom_count = max(1, p_kingdom_count)
 
 var params: MapGenParams
 var rng: RandomNumberGenerator
@@ -47,7 +50,7 @@ func generate() -> Dictionary:
     print("[MapGenerator] placed %s cities" % cities.size())
 
     var region_stage = RegionGeneratorModule.new()
-    var regions: Dictionary = region_stage.generate_regions(cities)
+    var regions: Dictionary = region_stage.generate_regions(cities, params.kingdom_count)
     map_data["regions"] = regions
     print("[MapGenerator] generated %s regions" % regions.size())
 

--- a/game/map/Region.gd
+++ b/game/map/Region.gd
@@ -5,11 +5,18 @@ var id: int
 # Boundary of the region represented as a list of Vector2 points.
 var boundary_nodes: Array[Vector2]
 var narrator: String
+var kingdom_id: int
 
-func _init(_id: int, _boundary_nodes: Array = [], _narrator: String = "") -> void:
+func _init(
+    _id: int,
+    _boundary_nodes: Array = [],
+    _narrator: String = "",
+    _kingdom_id: int = 0
+) -> void:
     id = _id
     boundary_nodes = _boundary_nodes
     narrator = _narrator
+    kingdom_id = _kingdom_id
 
 func to_dict() -> Dictionary:
     var pts: Array = []
@@ -19,4 +26,5 @@ func to_dict() -> Dictionary:
         "id": id,
         "boundary_nodes": pts,
         "narrator": narrator,
+        "kingdom_id": kingdom_id,
     }

--- a/game/ui/MapView.gd
+++ b/game/ui/MapView.gd
@@ -77,7 +77,7 @@ func _draw() -> void:
             if not debug_logged:
                 print("[MapView] region %s screen pts: %s" % [region.id, pts])
             if pts.size() >= 3:
-                var base_color := Color.from_hsv(hash(region.id) % 360 / 360.0, 0.6, 0.8)
+                var base_color := Color.from_hsv(hash(region.kingdom_id) % 360 / 360.0, 0.6, 0.8)
                 var fill_color: Color = base_color
                 fill_color.a = 0.3
                 var outline_color: Color = base_color


### PR DESCRIPTION
## Summary
- allow configuring number of kingdoms in map generation
- track `kingdom_id` for regions and assign contiguous clusters
- color regions in the map view by kingdom ownership

## Testing
- `bash ./tools/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0d544bc88832892b05c3846f20e7a