### PR TITLE
fix: correct kingdom name edit signal argument order

### DIFF
--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -247,7 +247,7 @@ func _populate_kingdom_legend() -> void:
         name_edit.text_changed.connect(_on_kingdom_name_changed.bind(kingdom_id))
         entry.add_child(name_edit)
 
-func _on_kingdom_name_changed(kingdom_id: int, text: String) -> void:
+func _on_kingdom_name_changed(text: String, kingdom_id: int) -> void:
     if not current_map.has("kingdom_names"):
         current_map["kingdom_names"] = {}
     current_map["kingdom_names"][kingdom_id] = text


### PR DESCRIPTION
## Summary
- swap `_on_kingdom_name_changed` parameters to receive text before kingdom ID

## Testing
- `./tools/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1942af0388328becbc2936ad55668