### PR TITLE
feat: support editing city positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+0.1.27 — 2025-09-10
+Fixed
+- Linked disconnected road graphs when Delaunay triangulation produced no edges, preventing hangs on some random seeds.
+
 0.1.26 — 2025-09-10
 Added
 - Documented `version` and `rng_seed` as unsafe variable names in naming guidelines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog
 
+0.1.26 — 2025-09-10
+Added
+- Documented `version` and `rng_seed` as unsafe variable names in naming guidelines.
+Fixed
+- Renamed shadowed snapshot parameters and limited road crossing insertion iterations to guard against bad random seeds.
+
 0.1.25 — 2025-09-10
 Added
 - Documented `params` as an unsafe variable name in naming guidelines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 Changelog
 
+0.1.28 — 2025-09-10
+Removed
+- Reverted addition of `version` and `rng_seed` to unsafe variable names list.
+
 0.1.27 — 2025-09-10
 Fixed
 - Linked disconnected road graphs when Delaunay triangulation produced no edges, preventing hangs on some random seeds.
 
 0.1.26 — 2025-09-10
-Added
-- Documented `version` and `rng_seed` as unsafe variable names in naming guidelines.
 Fixed
 - Renamed shadowed snapshot parameters and limited road crossing insertion iterations to guard against bad random seeds.
 

--- a/RULES_ALWAYS_READ.md
+++ b/RULES_ALWAYS_READ.md
@@ -17,7 +17,7 @@ RULES_ALWAYS_READ — twarde zasady
   - `enter_tree`, `exit_tree`
   - `duplicate`, `free`, `queue_free`
   - `update`, `draw`, `play`, `stop`
-  - `scale`, `seed`, `params`
+  - `scale`, `seed`, `params`, `version`, `rng_seed`
 - Autoloady (nazwy singletonów): `App`, `I18N`, `Net`, `World`, później `Debug`, `Ai`.
 
 3) I18N (obowiązkowe)

--- a/RULES_ALWAYS_READ.md
+++ b/RULES_ALWAYS_READ.md
@@ -17,7 +17,7 @@ RULES_ALWAYS_READ — twarde zasady
   - `enter_tree`, `exit_tree`
   - `duplicate`, `free`, `queue_free`
   - `update`, `draw`, `play`, `stop`
-  - `scale`, `seed`, `params`, `version`, `rng_seed`
+  - `scale`, `seed`, `params`
 - Autoloady (nazwy singletonów): `App`, `I18N`, `Net`, `World`, później `Debug`, `Ai`.
 
 3) I18N (obowiązkowe)

--- a/game/map/MapSnapshot.gd
+++ b/game/map/MapSnapshot.gd
@@ -14,8 +14,8 @@ func _init(p_rng_seed: int, p_version: String) -> void:
     edges = {}
     regions = {}
 
-static func from_map(map_data: Dictionary, rng_seed: int, version: String) -> MapSnapshot:
-    var snapshot := MapSnapshot.new(rng_seed, version)
+static func from_map(map_data: Dictionary, p_rng_seed: int, p_version: String) -> MapSnapshot:
+    var snapshot := MapSnapshot.new(p_rng_seed, p_version)
     var roads: Dictionary = map_data.get("roads", {})
     for node in roads.get("nodes", {}).values():
         snapshot.nodes[node.id] = node

--- a/game/map/MapSnapshot.gd
+++ b/game/map/MapSnapshot.gd
@@ -14,6 +14,17 @@ func _init(p_rng_seed: int, p_version: String) -> void:
     edges = {}
     regions = {}
 
+static func from_map(map_data: Dictionary, rng_seed: int, version: String) -> MapSnapshot:
+    var snapshot := MapSnapshot.new(rng_seed, version)
+    var roads: Dictionary = map_data.get("roads", {})
+    for node in roads.get("nodes", {}).values():
+        snapshot.nodes[node.id] = node
+    for edge in roads.get("edges", {}).values():
+        snapshot.edges[edge.id] = edge
+    for region in map_data.get("regions", {}).values():
+        snapshot.regions[region.id] = region
+    return snapshot
+
 func to_dict() -> Dictionary:
     var node_list: Array = []
     for node in nodes.values():

--- a/game/map/RoadNetwork.gd
+++ b/game/map/RoadNetwork.gd
@@ -103,6 +103,12 @@ func _delaunay_edges(points: Array[Vector2]) -> Array[Vector2i]:
         _add_edge(edges_dict, tri[i], tri[i + 1])
         _add_edge(edges_dict, tri[i + 1], tri[i + 2])
         _add_edge(edges_dict, tri[i + 2], tri[i])
+    if edges_dict.is_empty():
+        var all_pairs: Array[Vector2i] = []
+        for i in range(points.size()):
+            for j in range(i + 1, points.size()):
+                all_pairs.append(Vector2i(i, j))
+        return all_pairs
     var result: Array[Vector2i] = []
     for v in edges_dict.values():
         result.append(v)
@@ -140,6 +146,19 @@ func _minimum_spanning_tree(points: Array[Vector2], edges: Array[Vector2i]) -> A
                 if d < best_dist:
                     best_dist = d
                     best_edge = Vector2i(a, b)
+        if best_edge.y == -1:
+            var a_id: int = connected[0]
+            var b_id: int = remaining[0]
+            best_dist = points[a_id].distance_to(points[b_id])
+            for a in connected:
+                for b in remaining:
+                    var d: float = points[a].distance_to(points[b])
+                    if d < best_dist:
+                        best_dist = d
+                        a_id = a
+                        b_id = b
+            best_edge = Vector2i(a_id, b_id)
+            push_warning("[RoadNetwork] disconnected graph; forcing MST link")
         result.append(best_edge)
         connected.append(best_edge.y)
         remaining.erase(best_edge.y)

--- a/game/map/RoadNetwork.gd
+++ b/game/map/RoadNetwork.gd
@@ -148,9 +148,12 @@ func _minimum_spanning_tree(points: Array[Vector2], edges: Array[Vector2i]) -> A
 func _insert_crossings(nodes: Dictionary, edges: Dictionary, next_node_id: int, next_edge_id: int) -> Dictionary:
     var edge_ids = edges.keys()
     var changed := true
-    while changed:
+    var iterations: int = 0
+    var max_iterations: int = 1000
+    while changed and iterations < max_iterations:
         changed = false
         edge_ids = edges.keys()
+        iterations += 1
         for i in range(edge_ids.size()):
             var id_a: int = edge_ids[i]
             var edge_a: Edge = edges[id_a]
@@ -192,7 +195,8 @@ func _insert_crossings(nodes: Dictionary, edges: Dictionary, next_node_id: int, 
                 break
             if changed:
                 break
-
+    if iterations == max_iterations:
+        push_warning("[RoadNetwork] crossing insertion iteration limit reached")
     return {
         "next_node_id": next_node_id,
         "next_edge_id": next_edge_id,

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -214,7 +214,7 @@ func _on_edit_cities_toggled(pressed: bool) -> void:
 
 func _on_random_seed_pressed() -> void:
     seed_spin.set_block_signals(true)
-    var random_value: int = randi() % int(seed_spin.max_value)
+    var random_value: int = randi_range(1, int(seed_spin.max_value))
     seed_spin.value = random_value
     seed_spin.set_block_signals(false)
     _on_params_changed(0.0)

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -1,6 +1,9 @@
 extends Control
 
 const MapGeneratorModule = preload("res://map/MapGenerator.gd")
+const RegionGeneratorModule = preload("res://map/RegionGenerator.gd")
+const RoadNetworkModule = preload("res://map/RoadNetwork.gd")
+const MapSnapshotModule = preload("res://map/MapSnapshot.gd")
 
 @onready var title_label: Label = $HBox/ControlsScroll/Controls/Title
 @onready var params: GridContainer = $HBox/ControlsScroll/Controls/Params
@@ -34,6 +37,7 @@ const MapGeneratorModule = preload("res://map/MapGenerator.gd")
 @onready var show_cities_check: CheckBox = $Layers/ShowCities
 @onready var show_crossings_check: CheckBox = $Layers/ShowCrossings
 @onready var show_regions_check: CheckBox = $Layers/ShowRegions
+@onready var edit_cities_check: CheckBox = $Layers/EditCities
 @onready var start_button: Button = $HBox/ControlsScroll/Controls/Buttons/Start
 @onready var back_button: Button = $HBox/ControlsScroll/Controls/Buttons/Back
 @onready var main_ui: HBoxContainer = $HBox
@@ -43,6 +47,7 @@ var debounce_timer: Timer = Timer.new()
 
 var current_map: Dictionary = {}
 var previous_state: String = Net.state
+var app_version: String = ""
 
 func _ready() -> void:
     I18N.language_changed.connect(_update_texts)
@@ -52,6 +57,10 @@ func _ready() -> void:
     debounce_timer.one_shot = true
     debounce_timer.wait_time = 0.3
     debounce_timer.timeout.connect(_generate_map)
+    var vf := FileAccess.open("res://VERSION", FileAccess.READ)
+    if vf:
+        app_version = vf.get_as_text().strip_edges()
+        vf.close()
     random_seed_button.pressed.connect(_on_random_seed_pressed)
     start_button.pressed.connect(_on_start_pressed)
     back_button.pressed.connect(_on_back_pressed)
@@ -71,11 +80,13 @@ func _ready() -> void:
     show_cities_check.toggled.connect(_on_show_cities_toggled)
     show_crossings_check.toggled.connect(_on_show_crossings_toggled)
     show_regions_check.toggled.connect(_on_show_regions_toggled)
+    edit_cities_check.toggled.connect(_on_edit_cities_toggled)
     map_view.set_show_roads(show_roads_check.button_pressed)
     map_view.set_show_rivers(show_rivers_check.button_pressed)
     map_view.set_show_cities(show_cities_check.button_pressed)
     map_view.set_show_crossings(show_crossings_check.button_pressed)
     map_view.set_show_regions(show_regions_check.button_pressed)
+    map_view.cities_changed.connect(_on_cities_changed)
     _update_texts()
     _generate_map()
     _on_net_state_changed(Net.state)
@@ -99,6 +110,7 @@ func _update_texts() -> void:
     show_cities_check.text = I18N.t("setup.show_cities")
     show_crossings_check.text = I18N.t("setup.show_crossings")
     show_regions_check.text = I18N.t("setup.show_regions")
+    edit_cities_check.text = I18N.t("setup.edit_cities")
     start_button.text = I18N.t("setup.start")
     back_button.text = I18N.t("menu.back")
 
@@ -175,6 +187,7 @@ func _generate_map() -> void:
         kingdoms_spin.set_block_signals(false)
     _populate_kingdom_legend()
     start_button.disabled = false
+    _update_snapshot()
 
 func _on_params_changed(_value: float) -> void:
     start_button.disabled = true
@@ -196,6 +209,9 @@ func _on_show_crossings_toggled(pressed: bool) -> void:
 func _on_show_regions_toggled(pressed: bool) -> void:
     map_view.set_show_regions(pressed)
 
+func _on_edit_cities_toggled(pressed: bool) -> void:
+    map_view.set_edit_mode(pressed)
+
 func _on_random_seed_pressed() -> void:
     seed_spin.set_block_signals(true)
     var random_value: int = randi() % int(seed_spin.max_value)
@@ -204,6 +220,7 @@ func _on_random_seed_pressed() -> void:
     _on_params_changed(0.0)
 
 func _on_start_pressed() -> void:
+    _update_snapshot()
     match Net.run_mode:
         "single":
             Net.start_singleplayer()
@@ -251,3 +268,20 @@ func _on_kingdom_name_changed(text: String, kingdom_id: int) -> void:
     if not current_map.has("kingdom_names"):
         current_map["kingdom_names"] = {}
     current_map["kingdom_names"][kingdom_id] = text
+
+func _on_cities_changed(cities: Array) -> void:
+    current_map["cities"] = cities
+    var region_stage = RegionGeneratorModule.new()
+    var regions = region_stage.generate_regions(cities, int(kingdoms_spin.value), current_map.get("width", 100.0), current_map.get("height", 100.0))
+    current_map["regions"] = regions
+    var rng := RandomNumberGenerator.new()
+    rng.seed = int(seed_spin.value)
+    var road_stage := RoadNetworkModule.new(rng)
+    var roads = road_stage.build_roads(cities, int(min_connections_spin.value), int(max_connections_spin.value), crossing_margin_spin.value)
+    current_map["roads"] = roads
+    map_view.set_map_data(current_map)
+    _update_snapshot()
+
+func _update_snapshot() -> void:
+    var snapshot := MapSnapshotModule.from_map(current_map, int(seed_spin.value), app_version)
+    current_map["snapshot"] = snapshot.to_dict()

--- a/game/ui/MapSetupScreen.tscn
+++ b/game/ui/MapSetupScreen.tscn
@@ -172,3 +172,6 @@ button_pressed = false
 [node name="ShowRegions" type="CheckBox" parent="Layers"]
 button_pressed = true
 
+[node name="EditCities" type="CheckBox" parent="Layers"]
+button_pressed = false
+

--- a/game/ui/MapSetupScreen.tscn
+++ b/game/ui/MapSetupScreen.tscn
@@ -15,13 +15,13 @@ size_flags_vertical = 3
 [node name="ControlsScroll" type="ScrollContainer" parent="HBox"]
 size_flags_horizontal = 3
 size_flags_vertical = 3
-size_flags_stretch_ratio = 0.4
+size_flags_stretch_ratio = 0.3
 horizontal_scroll_enabled = false
 
 [node name="MapRow" type="HBoxContainer" parent="HBox"]
 size_flags_horizontal = 3
 size_flags_vertical = 3
-size_flags_stretch_ratio = 0.6
+size_flags_stretch_ratio = 0.7
 
 [node name="MapView" type="Control" parent="HBox/MapRow"]
 custom_minimum_size = Vector2(0, 400)
@@ -46,105 +46,117 @@ size_flags_horizontal = 3
 [node name="SeedLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="SeedRow" type="HBoxContainer" parent="HBox/ControlsScroll/Controls/Params"]
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="Seed" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params/SeedRow"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 0.0
 max_value = 1.0e+09
 step = 1.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="RandomSeed" type="Button" parent="HBox/ControlsScroll/Controls/Params/SeedRow"]
+size_flags_horizontal = 4
 
 [node name="CitiesLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="Cities" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 1.0
 max_value = 20.0
 step = 1.0
 value = 3.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="MinCitySpacingLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="MinCitySpacing" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 1.0
 max_value = 100.0
 step = 1.0
 value = 20.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="MaxCitySpacingLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="MaxCitySpacing" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 1.0
 max_value = 100.0
 step = 1.0
 value = 40.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="RiversLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="Rivers" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 0.0
 max_value = 10.0
 step = 1.0
 value = 1.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="KingdomsLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="Kingdoms" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 1.0
 max_value = 20.0
 step = 1.0
 value = 1.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="MinConnectionsLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="MinConnections" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 1.0
 max_value = 10.0
 step = 1.0
 value = 1.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="MaxConnectionsLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="MaxConnections" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 1.0
 max_value = 10.0
 step = 1.0
 value = 3.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="CrossingMarginLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="CrossingMargin" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 0.0
 max_value = 50.0
 step = 0.5
 value = 5.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="WidthLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="Width" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 20.0
 max_value = 500.0
 step = 10.0
 value = 100.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 [node name="HeightLabel" type="Label" parent="HBox/ControlsScroll/Controls/Params"]
 
 [node name="Height" type="SpinBox" parent="HBox/ControlsScroll/Controls/Params"]
+custom_minimum_size = Vector2(100, 0)
 min_value = 20.0
 max_value = 500.0
 step = 10.0
 value = 100.0
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 
 
 [node name="Buttons" type="HBoxContainer" parent="HBox/ControlsScroll/Controls"]


### PR DESCRIPTION
## Summary
- allow toggling an Edit Cities mode to drag city markers on the setup screen
- regenerate regions and roads after moving cities and keep a MapSnapshot up to date
- add map snapshot creation helper

## Testing
- `./tools/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c194d6f5448328b2d7f5b07ec5d336