### PR TITLE
feat: introduce stage seeds and world data container

### DIFF
--- a/game/map/MapGenerator.gd
+++ b/game/map/MapGenerator.gd
@@ -4,6 +4,11 @@ class_name MapGenerator
 ## Parameter container for map generation.
 class MapGenParams:
     var rng_seed: int
+    var seed_terrain: int
+    var seed_climate: int
+    var seed_hydrology: int
+    var seed_settlements: int
+    var seed_roads: int
     var city_count: int
     var max_river_count: int
     var min_connections: int
@@ -34,9 +39,21 @@ class MapGenParams:
         p_max_forts_per_kingdom: int = 1,
         p_min_villages_per_city: int = 0,
         p_max_villages_per_city: int = 2,
-        p_village_downgrade_threshold: int = 1
+        p_village_downgrade_threshold: int = 1,
+        p_seed_terrain: int = 0,
+        p_seed_climate: int = 0,
+        p_seed_hydrology: int = 0,
+        p_seed_settlements: int = 0,
+        p_seed_roads: int = 0
     ) -> void:
         rng_seed = p_rng_seed if p_rng_seed != 0 else Time.get_ticks_msec()
+        var base_rng := RandomNumberGenerator.new()
+        base_rng.seed = rng_seed
+        seed_terrain = p_seed_terrain if p_seed_terrain != 0 else base_rng.randi()
+        seed_climate = p_seed_climate if p_seed_climate != 0 else base_rng.randi()
+        seed_hydrology = p_seed_hydrology if p_seed_hydrology != 0 else base_rng.randi()
+        seed_settlements = p_seed_settlements if p_seed_settlements != 0 else base_rng.randi()
+        seed_roads = p_seed_roads if p_seed_roads != 0 else base_rng.randi()
         city_count = p_city_count
         max_river_count = p_max_river_count
         var max_possible: int = min(7, max(1, p_city_count - 1))
@@ -54,24 +71,35 @@ class MapGenParams:
         village_downgrade_threshold = max(1, p_village_downgrade_threshold)
 
 var params: MapGenParams
-var rng: RandomNumberGenerator
+var rngs: Dictionary = {}
 
 const CityPlacerModule = preload("res://map/CityPlacer.gd")
 const RoadNetworkModule = preload("res://map/RoadNetwork.gd")
 const RiverGeneratorModule: Script = preload("res://map/RiverGenerator.gd")
 const RegionGeneratorModule: Script = preload("res://map/RegionGenerator.gd")
+const WorldDataModule: Script = preload("res://map/WorldData.gd")
 
 func _init(_params: MapGenParams = MapGenParams.new()) -> void:
     params = _params
-    rng = RandomNumberGenerator.new()
-    rng.seed = params.rng_seed
+    rngs["terrain"] = RandomNumberGenerator.new()
+    rngs["terrain"].seed = params.seed_terrain
+    rngs["climate"] = RandomNumberGenerator.new()
+    rngs["climate"].seed = params.seed_climate
+    rngs["hydrology"] = RandomNumberGenerator.new()
+    rngs["hydrology"].seed = params.seed_hydrology
+    rngs["settlements"] = RandomNumberGenerator.new()
+    rngs["settlements"].seed = params.seed_settlements
+    rngs["roads"] = RandomNumberGenerator.new()
+    rngs["roads"].seed = params.seed_roads
 
 func generate() -> Dictionary:
     var map_data: Dictionary = {
         "width": params.width,
         "height": params.height,
     }
-    var city_stage := CityPlacerModule.new(rng)
+    var world := WorldDataModule.new(params.width, params.height)
+
+    var city_stage := CityPlacerModule.new(rngs["settlements"])
     var cities := city_stage.place_cities(
         params.city_count,
         params.min_city_distance,
@@ -80,27 +108,51 @@ func generate() -> Dictionary:
         params.height
     )
     map_data["cities"] = cities
+    var city_guids: Array[String] = []
+    for pos in cities:
+        var guid := world.add_vector("cities", {"pos": pos}, "")
+        city_guids.append(guid)
     print("[MapGenerator] placed %s cities" % cities.size())
 
     var region_stage = RegionGeneratorModule.new()
     var regions: Dictionary = region_stage.generate_regions(cities, params.kingdom_count, params.width, params.height)
     map_data["regions"] = regions
+    world.add_graph("regions", regions)
     print("[MapGenerator] generated %s regions" % regions.size())
 
-    var road_stage := RoadNetworkModule.new(rng)
+    var road_stage := RoadNetworkModule.new(rngs["roads"])
     var roads := road_stage.build_roads(
         cities,
         params.min_connections,
         params.max_connections,
         params.crossroad_detour_margin,
-        "roman"
+        "roman",
     )
     road_stage.insert_villages(roads, params.min_villages_per_city, params.max_villages_per_city, 5.0, params.width, params.height, params.village_downgrade_threshold)
     road_stage.insert_border_forts(roads, regions, 10.0, params.max_forts_per_kingdom, params.width, params.height)
-    map_data["roads"] = roads
 
-    var river_stage = RiverGeneratorModule.new(rng)
+    var river_stage = RiverGeneratorModule.new(rngs["hydrology"])
     var rivers: Array = river_stage.generate_rivers(roads, params.max_river_count, params.width, params.height)
     map_data["rivers"] = rivers
+    for poly in rivers:
+        world.add_vector("rivers", {"polyline": poly}, "")
+
+    for i in range(city_guids.size()):
+        var node_id: int = i + 1
+        if roads["nodes"].has(node_id):
+            roads["nodes"][node_id].attrs["guid"] = city_guids[i]
+
+    world.add_graph("roads", roads)
+
+    for edge in roads.get("edges", {}).values():
+        var a_id: int = edge.endpoints[0]
+        var b_id: int = edge.endpoints[1]
+        var a_guid: String = roads["nodes"][a_id].attrs.get("guid", "")
+        var b_guid: String = roads["nodes"][b_id].attrs.get("guid", "")
+        if a_guid != "" and b_guid != "":
+            edge.attrs["derived_from"] = "%s,%s" % [a_guid, b_guid]
+
+    map_data["roads"] = roads
+    map_data["world_data"] = world
 
     return map_data

--- a/game/map/WorldData.gd
+++ b/game/map/WorldData.gd
@@ -1,0 +1,45 @@
+extends RefCounted
+class_name WorldData
+
+var width: float
+var height: float
+var rasters: Dictionary = {}
+var vectors: Dictionary = {}
+var _guid_counters: Dictionary = {}
+
+func _init(_width: float = 100.0, _height: float = 100.0) -> void:
+    width = _width
+    height = _height
+
+func _next_guid(scope: String) -> String:
+    var idx: int = _guid_counters.get(scope, 1)
+    _guid_counters[scope] = idx + 1
+    return "%s:%d" % [scope, idx]
+
+func add_raster(name: String, data) -> void:
+    rasters[name] = data
+
+func add_vector(name: String, feature: Dictionary, derived_from: String = "") -> String:
+    feature["id"] = _next_guid(name)
+    feature["derived_from"] = derived_from
+    if not vectors.has(name):
+        vectors[name] = []
+    vectors[name].append(feature)
+    return feature["id"]
+
+func add_graph(name: String, graph: Dictionary) -> void:
+    var nodes: Dictionary = graph.get("nodes", {})
+    for node in nodes.values():
+        if not node.attrs.has("guid"):
+            node.attrs["guid"] = _next_guid(name + "_node")
+    var edges: Dictionary = graph.get("edges", {})
+    for edge in edges.values():
+        if not edge.attrs.has("guid"):
+            edge.attrs["guid"] = _next_guid(name + "_edge")
+    vectors[name] = graph
+
+func get_raster(name: String):
+    return rasters.get(name)
+
+func get_vector(name: String):
+    return vectors.get(name)


### PR DESCRIPTION
## Summary
- add stage-specific RNG seeds to map generation parameters
- build stage RNGs and world data container for features with provenance
- scaffold world data class to store rasters and graphs with GUIDs

## Testing
- `./tools/check.sh game`


------
https://chatgpt.com/codex/tasks/task_e_68c3e00cbb908328b20f5b77c6e91a85