### PR TITLE
Refactor map generation into staged pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+Unreleased
+Changed
+- Replaced the monolithic map generator with a staged pipeline that shares a seeded context across terrain, rivers, biomes, kingdom borders, settlements, roads, and forts.
+
 0.1.81 — 2025-09-14
 Added
 - CLI smoke test wiring that runs the map generator when `MAPGEN_SMOKE_TEST=1` or via `tests/MapGeneratorSmokeTest.gd`, enabling automated regression checks.

--- a/docs/design/Game_Design_and_Loops.md
+++ b/docs/design/Game_Design_and_Loops.md
@@ -59,7 +59,7 @@ flowchart LR
 
 ## Implementacja
 - Specyfikacja i zachowanie mapy: `/docs/map`.
-- Implementacja referencyjna: [MapGenerator.gd](../../game/mapgen/MapGenerator.gd).
+- Implementacja referencyjna: [MapGenerationPipeline.gd](../../game/mapgen/pipeline/MapGenerationPipeline.gd).
 - Przydział i kształt regionów: [RegionGenerator.gd](../../game/mapgen/RegionGenerator.gd).
 
 ## Rozszerzenia

--- a/game/autoload/App.gd
+++ b/game/autoload/App.gd
@@ -15,7 +15,7 @@ func goto_scene(path: String) -> void:
 
 func _run_map_generator_smoke_test() -> void:
     ResourceLoader.load("res://mapgen/CityPlacer.gd")
-    var generator_script: GDScript = ResourceLoader.load("res://mapgen/MapGenerator.gd")
+    var generator_script: GDScript = ResourceLoader.load("res://mapgen/pipeline/MapGenerationPipeline.gd")
     var generator: RefCounted = generator_script.new()
     var data: Dictionary = generator.generate()
     var cities: Array = data.get("cities", [])

--- a/game/mapgen/pipeline/BiomeStage.gd
+++ b/game/mapgen/pipeline/BiomeStage.gd
@@ -1,0 +1,35 @@
+extends RefCounted
+
+func run(context: RefCounted) -> void:
+    var fertility: Array = context.get_raster_layer("fertility", [])
+    var roughness: Array = context.get_raster_layer("roughness", [])
+    if fertility.is_empty():
+        context.set_raster_layer("biomes", [])
+        return
+    var biome_rows: Array = []
+    for y in range(fertility.size()):
+        var fert_row: Array = fertility[y]
+        var rough_row: Array = [] if y >= roughness.size() else roughness[y]
+        var biome_row: Array[String] = []
+        for x in range(fert_row.size()):
+            var f_val: float = fert_row[x]
+            var r_val: float = 0.0
+            if x < rough_row.size():
+                r_val = rough_row[x]
+            var biome: String = _classify_cell(f_val, r_val)
+            biome_row.append(biome)
+        biome_rows.append(biome_row)
+    context.set_raster_layer("biomes", biome_rows)
+
+func _classify_cell(fertility_value: float, roughness_value: float) -> String:
+    if fertility_value >= 0.66:
+        if roughness_value <= 0.33:
+            return "lush_plains"
+        return "dense_forest"
+    if fertility_value >= 0.33:
+        if roughness_value <= 0.33:
+            return "rolling_hills"
+        return "highlands"
+    if roughness_value <= 0.25:
+        return "dry_steppe"
+    return "barren"

--- a/game/mapgen/pipeline/FortsStage.gd
+++ b/game/mapgen/pipeline/FortsStage.gd
@@ -1,0 +1,31 @@
+extends RefCounted
+
+const RoadNetworkModule: Script = preload("res://mapview/RoadNetwork.gd")
+const MapNodeModule: Script = preload("res://mapview/MapNode.gd")
+
+func run(context: RefCounted) -> void:
+    var roads: Dictionary = context.get_vector_layer("roads", {})
+    var regions: Dictionary = context.get_vector_layer("regions", {})
+    if roads.is_empty() or regions.is_empty():
+        return
+    var params: Variant = context.params
+    var rng: RandomNumberGenerator = context.get_stage_rng("forts")
+    var helper = RoadNetworkModule.new(rng)
+    helper.insert_border_forts(
+        roads,
+        regions,
+        10.0,
+        params.max_forts_per_kingdom,
+        params.width,
+        params.height
+    )
+    context.set_vector_layer("roads", roads)
+    context.set_vector_layer("forts", _collect_forts(roads))
+
+func _collect_forts(roads: Dictionary) -> Array[Vector2]:
+    var forts: Array[Vector2] = []
+    var nodes: Dictionary = roads.get("nodes", {})
+    for node in nodes.values():
+        if node.type == MapNodeModule.TYPE_FORT:
+            forts.append(node.pos2d)
+    return forts

--- a/game/mapgen/pipeline/KingdomBordersStage.gd
+++ b/game/mapgen/pipeline/KingdomBordersStage.gd
@@ -1,0 +1,18 @@
+extends RefCounted
+
+func run(context: RefCounted) -> void:
+    var params: Variant = context.params
+    var rng: RandomNumberGenerator = context.get_stage_rng("kingdom_borders")
+    var margin: float = 20.0
+    var seeds: Array[Vector2] = []
+    for i in range(params.kingdom_count):
+        var pos := Vector2(
+            rng.randf_range(margin, max(margin, params.width - margin)),
+            rng.randf_range(margin, max(margin, params.height - margin))
+        )
+        seeds.append(pos)
+    context.set_vector_layer("kingdom_seeds", seeds)
+    var names: Dictionary = {}
+    for i in range(params.kingdom_count):
+        names[i + 1] = "Kingdom %d" % (i + 1)
+    context.set_data("kingdom_names", names)

--- a/game/mapgen/pipeline/MapGenerationPipeline.gd
+++ b/game/mapgen/pipeline/MapGenerationPipeline.gd
@@ -1,0 +1,237 @@
+extends RefCounted
+class_name MapGenPipeline
+
+const TerrainStageModule: Script = preload("res://mapgen/pipeline/TerrainStage.gd")
+const RiverStageModule: Script = preload("res://mapgen/pipeline/RiverStage.gd")
+const BiomeStageModule: Script = preload("res://mapgen/pipeline/BiomeStage.gd")
+const KingdomBordersStageModule: Script = preload("res://mapgen/pipeline/KingdomBordersStage.gd")
+const CitiesVillagesStageModule: Script = preload("res://mapgen/pipeline/CitiesVillagesStage.gd")
+const RoadsStageModule: Script = preload("res://mapgen/pipeline/RoadsStage.gd")
+const FortsStageModule: Script = preload("res://mapgen/pipeline/FortsStage.gd")
+const MapNodeModule: Script = preload("res://mapview/MapNode.gd")
+
+## Parameter container for map generation.
+class MapGenParams:
+    var rng_seed: int
+    var city_count: int
+    var max_river_count: int
+    var min_connections: int
+    var max_connections: int
+    var min_city_distance: float
+    var max_city_distance: float
+    var crossroad_detour_margin: float
+    var width: float
+    var height: float
+    var kingdom_count: int
+    var max_forts_per_kingdom: int
+    var village_count: int
+    var village_per_city: int
+
+    func _init(
+        p_rng_seed: int = 0,
+        p_city_count: int = 6,
+        p_max_river_count: int = 1,
+        p_min_connections: int = 1,
+        p_max_connections: int = 3,
+        p_min_city_distance: float = 20.0,
+        p_max_city_distance: float = 40.0,
+        p_crossroad_detour_margin: float = 5.0,
+        p_width: float = 150.0,
+        p_height: float = 150.0,
+        p_kingdom_count: int = 3,
+        p_max_forts_per_kingdom: int = 1,
+        p_village_count: int = 10,
+        p_village_per_city: int = 2
+    ) -> void:
+        rng_seed = p_rng_seed if p_rng_seed != 0 else Time.get_ticks_msec()
+        city_count = p_city_count
+        max_river_count = p_max_river_count
+        var max_possible: int = min(7, max(1, p_city_count - 1))
+        min_connections = clamp(p_min_connections, 1, max_possible)
+        max_connections = clamp(p_max_connections, min_connections, max_possible)
+        min_city_distance = min(p_min_city_distance, p_max_city_distance)
+        max_city_distance = max(p_min_city_distance, p_max_city_distance)
+        crossroad_detour_margin = p_crossroad_detour_margin
+        width = clamp(p_width, 20.0, 500.0)
+        height = clamp(p_height, 20.0, 500.0)
+        kingdom_count = max(1, p_kingdom_count)
+        max_forts_per_kingdom = max(0, p_max_forts_per_kingdom)
+        village_count = max(0, p_village_count)
+        village_per_city = max(0, p_village_per_city)
+
+class MapGenContext:
+    var params: MapGenParams
+    var rng_seed: int
+    var base_rng: RandomNumberGenerator
+    var stage_rngs: Dictionary
+    var vector_layers: Dictionary
+    var raster_layers: Dictionary
+    var data: Dictionary
+
+    func _init(_params: MapGenParams) -> void:
+        params = _params
+        rng_seed = params.rng_seed
+        base_rng = RandomNumberGenerator.new()
+        base_rng.seed = rng_seed
+        stage_rngs = {}
+        vector_layers = {}
+        raster_layers = {}
+        data = {}
+
+    func get_stage_rng(stage_id: String) -> RandomNumberGenerator:
+        if stage_rngs.has(stage_id):
+            return stage_rngs[stage_id]
+        var rng := RandomNumberGenerator.new()
+        var hashed: int = hash([rng_seed, stage_id])
+        if hashed == 0:
+            hashed = rng_seed
+        rng.seed = hashed
+        stage_rngs[stage_id] = rng
+        return rng
+
+    func set_vector_layer(name: String, value: Variant) -> void:
+        vector_layers[name] = value
+
+    func get_vector_layer(name: String, default_value: Variant = null) -> Variant:
+        return vector_layers.get(name, default_value)
+
+    func set_raster_layer(name: String, value: Variant) -> void:
+        raster_layers[name] = value
+
+    func get_raster_layer(name: String, default_value: Variant = null) -> Variant:
+        return raster_layers.get(name, default_value)
+
+    func set_data(key: String, value: Variant) -> void:
+        data[key] = value
+
+    func get_data(key: String, default_value: Variant = null) -> Variant:
+        return data.get(key, default_value)
+
+var params: MapGenParams
+
+func _init(_params: MapGenParams = MapGenParams.new()) -> void:
+    params = _params
+
+func generate() -> Dictionary:
+    var context := MapGenContext.new(params)
+    var stages: Array[RefCounted] = [
+        TerrainStageModule.new(),
+        RiverStageModule.new(),
+        BiomeStageModule.new(),
+        KingdomBordersStageModule.new(),
+        CitiesVillagesStageModule.new(),
+        RoadsStageModule.new(),
+        FortsStageModule.new(),
+    ]
+    for stage in stages:
+        stage.run(context)
+    return _build_result(context)
+
+func _build_result(context: MapGenContext) -> Dictionary:
+    var map_data: Dictionary = {
+        "width": context.params.width,
+        "height": context.params.height,
+        "fertility": context.get_raster_layer("fertility", []),
+        "roughness": context.get_raster_layer("roughness", []),
+        "biomes": context.get_raster_layer("biomes", []),
+        "rivers": context.get_vector_layer("rivers", []),
+        "cities": context.get_vector_layer("cities", []),
+        "villages": context.get_vector_layer("villages", []),
+        "forts": context.get_vector_layer("forts", []),
+        "roads": context.get_vector_layer("roads", {}),
+        "regions": context.get_vector_layer("regions", {}),
+        "kingdom_seeds": context.get_vector_layer("kingdom_seeds", []),
+        "kingdom_names": context.get_data("kingdom_names", {}),
+        "capitals": context.get_data("capitals", []),
+    }
+    var roads: Dictionary = map_data.get("roads", {})
+    var nodes: Dictionary = roads.get("nodes", {})
+    for idx in map_data.get("capitals", []):
+        var nid: int = idx + 1
+        if nodes.has(nid):
+            var node: RefCounted = nodes[nid]
+            node.attrs["is_capital"] = true
+    return map_data
+
+static func export_bundle(path: String, map_data: Dictionary, rng_seed: int, version: String, width: float, height: float, unit_scale: float = 1.0) -> void:
+    var bundle: Dictionary = _bundle_from_map(map_data, rng_seed, version, width, height, unit_scale)
+    var file := FileAccess.open(path, FileAccess.WRITE)
+    if file != null:
+        file.store_string(JSON.stringify(bundle, "\t"))
+        file.close()
+
+static func _bundle_from_map(map_data: Dictionary, rng_seed: int, version: String, width: float, height: float, unit_scale: float) -> Dictionary:
+    var bundle: Dictionary = {
+        "meta": {
+            "version": version,
+            "seed": rng_seed,
+            "map_size": int(max(width, height)),
+            "unit_scale": unit_scale,
+        },
+        "fertility": map_data.get("fertility", []),
+        "roughness": map_data.get("roughness", []),
+        "nodes": [],
+        "edges": [],
+        "cities": [],
+        "crossings": [],
+        "forts": [],
+        "kingdoms": [],
+        "rivers": [],
+        "climate_cells": [],
+    }
+    var roads: Dictionary = map_data.get("roads", {})
+    var nodes: Dictionary = roads.get("nodes", {})
+    var capital_by_kingdom: Dictionary = {}
+    for node in nodes.values():
+        bundle["nodes"].append({"id": node.id, "x": node.pos2d.x, "y": node.pos2d.y})
+        match node.type:
+            MapNodeModule.TYPE_CITY:
+                var kid: int = node.attrs.get("kingdom_id", 0)
+                var is_cap: bool = node.attrs.get("is_capital", false)
+                bundle["cities"].append({"id": node.id, "x": node.pos2d.x, "y": node.pos2d.y, "kingdom_id": kid, "is_capital": is_cap})
+                if is_cap:
+                    capital_by_kingdom[kid] = node.id
+            MapNodeModule.TYPE_FORT:
+                bundle["forts"].append({"id": node.id, "x": node.pos2d.x, "y": node.pos2d.y, "edge_id": node.attrs.get("edge_id", null), "crossing_id": node.attrs.get("crossing_id", null), "pair_id": node.attrs.get("pair_id", null)})
+            MapNodeModule.TYPE_BRIDGE:
+                bundle["crossings"].append({"id": node.id, "x": node.pos2d.x, "y": node.pos2d.y, "type": "bridge", "river_id": node.attrs.get("river_id", null)})
+            MapNodeModule.TYPE_FORD:
+                bundle["crossings"].append({"id": node.id, "x": node.pos2d.x, "y": node.pos2d.y, "type": "ford", "river_id": node.attrs.get("river_id", null)})
+            _:
+                pass
+    var edges: Dictionary = roads.get("edges", {})
+    for edge in edges.values():
+        var length: float = 0.0
+        for i in range(edge.polyline.size() - 1):
+            length += edge.polyline[i].distance_to(edge.polyline[i + 1])
+        var edict: Dictionary = {
+            "id": edge.id,
+            "a": edge.endpoints[0],
+            "b": edge.endpoints[1],
+            "class": edge.road_class.capitalize(),
+            "length": length,
+        }
+        if edge.attrs.has("crossing_id"):
+            edict["crossing_id"] = edge.attrs["crossing_id"]
+        bundle["edges"].append(edict)
+    for river in map_data.get("rivers", []):
+        var poly: Array = []
+        for p in river:
+            poly.append([p.x, p.y])
+        bundle["rivers"].append({"id": bundle["rivers"].size() + 1, "polyline": poly})
+    var regions: Dictionary = map_data.get("regions", {})
+    var names: Dictionary = map_data.get("kingdom_names", {})
+    for region in regions.values():
+        var poly: Array = []
+        for p in region.boundary_nodes:
+            poly.append([p.x, p.y])
+        var kname: String = String(names.get(region.kingdom_id, "Kingdom %d" % region.kingdom_id))
+        var cap_id: int = capital_by_kingdom.get(region.kingdom_id, 0)
+        bundle["kingdoms"].append({
+            "id": region.id,
+            "kingdom_id": region.kingdom_id,
+            "name": kname,
+            "capital_city_id": cap_id,
+            "polygon": poly,
+        })
+    return bundle

--- a/game/mapgen/pipeline/RiverStage.gd
+++ b/game/mapgen/pipeline/RiverStage.gd
@@ -1,0 +1,16 @@
+extends RefCounted
+
+const RiverGeneratorModule: Script = preload("res://mapgen/RiverGenerator.gd")
+
+func run(context: RefCounted) -> void:
+    var params: Variant = context.params
+    var rng: RandomNumberGenerator = context.get_stage_rng("rivers")
+    var generator = RiverGeneratorModule.new(rng)
+    var placeholder_roads: Dictionary = {
+        "nodes": {},
+        "edges": {},
+        "next_node_id": 1,
+        "next_edge_id": 1,
+    }
+    var rivers: Array = generator.generate_rivers(placeholder_roads, params.max_river_count, params.width, params.height)
+    context.set_vector_layer("rivers", rivers)

--- a/game/mapgen/pipeline/RoadsStage.gd
+++ b/game/mapgen/pipeline/RoadsStage.gd
@@ -1,0 +1,49 @@
+extends RefCounted
+
+const RoadNetworkModule: Script = preload("res://mapview/RoadNetwork.gd")
+const MapNodeModule: Script = preload("res://mapview/MapNode.gd")
+const RiverGeneratorModule: Script = preload("res://mapgen/RiverGenerator.gd")
+
+func run(context: RefCounted) -> void:
+    var params: Variant = context.params
+    var cities: Array[Vector2] = context.get_vector_layer("cities", [])
+    if cities.is_empty():
+        context.set_vector_layer("roads", {})
+        return
+    var rng: RandomNumberGenerator = context.get_stage_rng("roads")
+    var road_stage = RoadNetworkModule.new(rng)
+    var roads: Dictionary = road_stage.build_roads(
+        cities,
+        params.min_connections,
+        params.max_connections,
+        params.crossroad_detour_margin,
+        "roman"
+    )
+    var villages: Array[Vector2] = context.get_vector_layer("villages", [])
+    if villages.size() > 0:
+        road_stage.insert_villages(roads, villages)
+    var regions: Dictionary = context.get_vector_layer("regions", {})
+    if not regions.is_empty():
+        _assign_kingdoms_to_cities(roads, regions)
+    var rivers: Array = context.get_vector_layer("rivers", [])
+    if rivers.size() > 0:
+        RiverGeneratorModule.apply_intersections(rivers, roads)
+    context.set_vector_layer("roads", roads)
+
+func _assign_kingdoms_to_cities(roads: Dictionary, regions: Dictionary) -> void:
+    var nodes: Dictionary = roads.get("nodes", {})
+    for node in nodes.values():
+        if node.type != MapNodeModule.TYPE_CITY:
+            continue
+        var region := _region_for_point(node.pos2d, regions)
+        if region != null:
+            node.attrs["kingdom_id"] = region.kingdom_id
+
+func _region_for_point(point: Vector2, regions: Dictionary) -> RefCounted:
+    for region in regions.values():
+        var pts := PackedVector2Array()
+        for vertex in region.boundary_nodes:
+            pts.append(vertex)
+        if Geometry2D.is_point_in_polygon(point, pts):
+            return region
+    return null

--- a/game/mapgen/pipeline/TerrainStage.gd
+++ b/game/mapgen/pipeline/TerrainStage.gd
@@ -1,0 +1,21 @@
+extends RefCounted
+
+const NoiseUtilModule: Script = preload("res://mapgen/NoiseUtil.gd")
+
+func run(context: RefCounted) -> void:
+    var params: Variant = context.params
+    var width_i: int = int(params.width)
+    var height_i: int = int(params.height)
+    var rng: RandomNumberGenerator = context.get_stage_rng("terrain")
+    var noise_seed: int = rng.randi()
+    var noise_util = NoiseUtilModule.new()
+    var fertility_field: Array = noise_util.generate_field(
+        noise_util.create_simplex(noise_seed, 3),
+        width_i,
+        height_i,
+        0.1
+    )
+    var roughness_field: Array = noise_util.compute_roughness(fertility_field)
+    context.set_raster_layer("fertility", fertility_field)
+    context.set_raster_layer("roughness", roughness_field)
+    context.set_data("terrain_seed", noise_seed)

--- a/game/project.godot
+++ b/game/project.godot
@@ -16,9 +16,9 @@ run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.4")
 script_classes=[{
 "base": "RefCounted",
-"class": "MapGenGenerator",
+"class": "MapGenPipeline",
 "language": "GDScript",
-"path": "res://mapgen/MapGenerator.gd"
+"path": "res://mapgen/pipeline/MapGenerationPipeline.gd"
 }, {
 "base": "RefCounted",
 "class": "MapGenCityPlacer",

--- a/game/scenes/Game.gd
+++ b/game/scenes/Game.gd
@@ -1,6 +1,6 @@
 extends Node
 
-const MapGeneratorModule = preload("res://mapgen/MapGenerator.gd")
+const MapGeneratorModule = preload("res://mapgen/pipeline/MapGenerationPipeline.gd")
 
 var map_data: Dictionary
 

--- a/game/tests/MapGeneratorSmokeTest.gd
+++ b/game/tests/MapGeneratorSmokeTest.gd
@@ -6,7 +6,7 @@ const RegionModule: GDScript = preload("res://mapview/Region.gd")
 const CityPlacerModule: GDScript = preload("res://mapgen/CityPlacer.gd")
 const RoadNetworkModule: GDScript = preload("res://mapview/RoadNetwork.gd")
 const RiverGeneratorModule: GDScript = preload("res://mapgen/RiverGenerator.gd")
-const MapGeneratorModule: GDScript = preload("res://mapgen/MapGenerator.gd")
+const MapGeneratorModule: GDScript = preload("res://mapgen/pipeline/MapGenerationPipeline.gd")
 
 func _init() -> void:
     var generator: RefCounted = MapGeneratorModule.new()

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -1,6 +1,6 @@
 extends Control
 
-const MapGeneratorModule = preload("res://mapgen/MapGenerator.gd")
+const MapGeneratorModule = preload("res://mapgen/pipeline/MapGenerationPipeline.gd")
 const RegionGeneratorModule = preload("res://mapgen/RegionGenerator.gd")
 const RoadNetworkModule = preload("res://mapview/RoadNetwork.gd")
 const MapSnapshotModule = preload("res://mapview/MapSnapshot.gd")


### PR DESCRIPTION
## Summary
- replace the monolithic map generator with a MapGenerationPipeline that coordinates staged terrain, river, biome, border, settlement, road, and fort passes using a shared context
- add dedicated stage scripts that read and write raster/vector layers for downstream consumers and propagate capitals, villages, rivers, and forts through the pipeline
- update the river generator, documentation, and callers to work with the new staged pipeline and record the change in the changelog

## Testing
- `godot --headless --path game --check mapgen/pipeline/MapGenerationPipeline.gd --quit`
- `for file in mapgen/pipeline/TerrainStage.gd mapgen/pipeline/RiverStage.gd mapgen/pipeline/BiomeStage.gd mapgen/pipeline/KingdomBordersStage.gd mapgen/pipeline/CitiesVillagesStage.gd mapgen/pipeline/RoadsStage.gd mapgen/pipeline/FortsStage.gd mapgen/RiverGenerator.gd autoload/App.gd scenes/Game.gd tests/MapGeneratorSmokeTest.gd ui/MapSetupScreen.gd; do godot --headless --path game --check "$file" --quit || exit 1; done`
- `godot --headless --path game --script tests/MapGeneratorSmokeTest.gd --quit`


------
https://chatgpt.com/codex/tasks/task_e_68c94857a4508328b680fc2832f7c268