### PR TITLE
fix: annotate map layer toggle capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changed
 - Map setup UI now binds seed, map size, kingdom count, terrain, road, and fort parameters directly to the generator and regenerates the MapView preview on each change.
 - Refactored the deterministic map generator into dedicated terrain, river, biome, kingdom, settlement, road, and fort stage scripts with shared utilities so the stub implementation is fully retired.
 - tools/check scripts now detect changed GDScript files and run `godot --check` on each script before executing the broader project checks.
+Fixed
+- Typed the layer toggle callback capture on MapSetupScreen so Godot can infer the signal parameter type.
 
 0.1.81 — 2025-09-14
 Added

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -169,7 +169,7 @@ func _setup_layer_toggles() -> void:
     }
     for layer_key in _layer_checkboxes.keys():
         var checkbox: CheckBox = _layer_checkboxes[layer_key]
-        var captured_layer := layer_key
+        var captured_layer: String = String(layer_key)
         checkbox.toggled.connect(func(pressed: bool) -> void:
             _on_layer_checkbox_toggled(captured_layer, pressed)
         )


### PR DESCRIPTION
## Summary
- ensure MapSetupScreen's layer toggle signal captures are typed so Godot can infer the parameter type
- record the regression fix in the changelog

## Testing
- godot --headless --path game --check ui/MapSetupScreen.gd *(hangs, aborted after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ca494c5c83289d18c4a556f91b25