### PR TITLE
feat: plan directional coastlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Unreleased
 Added
 - Nothing yet.
 Changed
-- Nothing yet.
+- Coastline generation now selects boundary sides, grows seawater inward with depth noise, and records the fill order for downstream consumers.
 Fixed
-- Nothing yet.
+- Coastline validation asserts side-front connectivity and verifies recorded sea counts against the planned fronts.
 
 0.2.0 — 2025-09-19
 Added


### PR DESCRIPTION
## Summary
- seed coastline generation from one or two boundary sides and expand queues inward while tracking fill order metadata
- persist selected coastline sides, fill order, and side counts in terrain results for downstream consumers
- validate that each side-front sea region stays connected and matches the recorded counts

## Testing
- godot --headless --path game --check mapgen/HexMapGenerator.gd --quit
- tools/check.sh game

------
https://chatgpt.com/codex/tasks/task_e_68cd2c00f6888328991e09774cd1708c