### PR TITLE
feat: implement river routing with validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added
 - Rivers now generate from mountain peaks, record per-hex masks, classes, mouths, and emit validation results for missing sinks.
 Changed
 - Plains carved by rivers automatically downgrade to valleys and lakes prefer to open downstream outlets when terrain allows.
+- Map generation defaults now start with mountain-mountain-hills-sea-sea-hills edge bands, edge jitter 3, and medium random features.
 Fixed
 - Corrected river peak ordering to compare coordinates without using the nonexistent `String` constructor in Godot 4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@ Changelog
 
 Unreleased
 Added
-- Nothing yet.
+- Rivers now generate from mountain peaks, record per-hex masks, classes, mouths, and emit validation results for missing sinks.
 Changed
-- Nothing yet.
+- Plains carved by rivers automatically downgrade to valleys and lakes prefer to open downstream outlets when terrain allows.
 Fixed
 - Nothing yet.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Added
 Changed
 - Plains carved by rivers automatically downgrade to valleys and lakes prefer to open downstream outlets when terrain allows.
 Fixed
-- Nothing yet.
+- Corrected river peak ordering to compare coordinates without using the nonexistent `String` constructor in Godot 4.
 
 0.2.1 — 2025-09-19
 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Added
 - Rivers now generate from mountain peaks, record per-hex masks, classes, mouths, and emit validation results for missing sinks.
 Changed
 - Plains carved by rivers automatically downgrade to valleys and lakes prefer to open downstream outlets when terrain allows.
-- Map generation defaults now start with mountain-mountain-hills-sea-sea-hills edge bands, edge jitter 3, and medium random features.
+- Map generation defaults now start with mountain-mountain-hills-sea-sea-hills edge bands, edge depths 2/2/2/54/5/2, edge jitter 3, and medium random features.
 Fixed
 - Corrected river peak ordering to compare coordinates without using the nonexistent `String` constructor in Godot 4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added
 Changed
 - Plains carved by rivers automatically downgrade to valleys and lakes prefer to open downstream outlets when terrain allows.
 - Map generation defaults now start with mountain-mountain-hills-sea-sea-hills edge bands, edge depths 2/2/2/54/5/2, edge jitter 3, and medium random features.
+- Default map seed now initializes to 666997 and the base radius default is 4 so generated maps start from the new baseline sizing.
 Fixed
 - Corrected river peak ordering to compare coordinates without using the nonexistent `String` constructor in Godot 4.
 

--- a/game/mapgen/HexMapConfig.gd
+++ b/game/mapgen/HexMapConfig.gd
@@ -1,7 +1,8 @@
 extends RefCounted
 class_name HexMapConfig
 
-const DEFAULT_MAP_RADIUS := 24
+const DEFAULT_MAP_SEED := 666997
+const DEFAULT_MAP_RADIUS := 4
 const DEFAULT_KINGDOM_COUNT := 3
 const DEFAULT_RIVERS_CAP := 6
 const DEFAULT_ROAD_AGGRESSIVENESS := 0.5
@@ -60,7 +61,7 @@ var edge_jitter: int
 var random_feature_density: float
 
 func _init(
-    p_seed: int = 0,
+    p_seed: int = DEFAULT_MAP_SEED,
     p_map_radius: int = DEFAULT_MAP_RADIUS,
     p_kingdom_count: int = DEFAULT_KINGDOM_COUNT,
     p_rivers_cap: int = DEFAULT_RIVERS_CAP,

--- a/game/mapgen/HexMapConfig.gd
+++ b/game/mapgen/HexMapConfig.gd
@@ -7,8 +7,8 @@ const DEFAULT_RIVERS_CAP := 6
 const DEFAULT_ROAD_AGGRESSIVENESS := 0.5
 const DEFAULT_FORT_GLOBAL_CAP := 6
 const DEFAULT_FORT_SPACING := 4
-const DEFAULT_EDGE_JITTER := 0
-const DEFAULT_RANDOM_FEATURE_DENSITY := 0.0
+const DEFAULT_EDGE_JITTER := 3
+const DEFAULT_RANDOM_FEATURE_DENSITY := 0.12
 
 const EDGE_NAMES: Array[String] = [
     "east",
@@ -29,6 +29,15 @@ const EDGE_TERRAIN_TYPES: Array[String] = [
 
 const DEFAULT_EDGE_TYPE := "plains"
 const DEFAULT_EDGE_WIDTH := 0
+
+const DEFAULT_EDGE_TERRAINS := {
+    "east": "mountains",
+    "north_east": "mountains",
+    "north_west": "hills",
+    "west": "sea",
+    "south_west": "sea",
+    "south_east": "hills",
+}
 
 var map_seed: int
 var map_radius: int
@@ -99,7 +108,7 @@ func to_dictionary() -> Dictionary:
 func get_edge_setting(edge_name: String) -> Dictionary:
     var sanitized := _sanitize_edge_settings(edge_settings)
     return sanitized.get(edge_name, {
-        "type": DEFAULT_EDGE_TYPE,
+        "type": DEFAULT_EDGE_TERRAINS.get(edge_name, DEFAULT_EDGE_TYPE),
         "width": DEFAULT_EDGE_WIDTH,
     })
 
@@ -123,9 +132,9 @@ func _sanitize_edge_settings(source: Dictionary) -> Dictionary:
         var entry: Dictionary = {}
         if typeof(source.get(edge_name)) == TYPE_DICTIONARY:
             entry = source[edge_name]
-        var terrain_type := String(entry.get("type", DEFAULT_EDGE_TYPE))
+        var terrain_type := String(entry.get("type", DEFAULT_EDGE_TERRAINS.get(edge_name, DEFAULT_EDGE_TYPE)))
         if not EDGE_TERRAIN_TYPES.has(terrain_type):
-            terrain_type = DEFAULT_EDGE_TYPE
+            terrain_type = DEFAULT_EDGE_TERRAINS.get(edge_name, DEFAULT_EDGE_TYPE)
         var width_value := int(entry.get("width", DEFAULT_EDGE_WIDTH))
         sanitized[edge_name] = {
             "type": terrain_type,

--- a/game/mapgen/HexMapConfig.gd
+++ b/game/mapgen/HexMapConfig.gd
@@ -30,6 +30,15 @@ const EDGE_TERRAIN_TYPES: Array[String] = [
 const DEFAULT_EDGE_TYPE := "plains"
 const DEFAULT_EDGE_WIDTH := 0
 
+const DEFAULT_EDGE_DEPTHS := {
+    "east": 2,
+    "north_east": 2,
+    "north_west": 2,
+    "west": 54,
+    "south_west": 5,
+    "south_east": 2,
+}
+
 const DEFAULT_EDGE_TERRAINS := {
     "east": "mountains",
     "north_east": "mountains",
@@ -107,9 +116,10 @@ func to_dictionary() -> Dictionary:
 
 func get_edge_setting(edge_name: String) -> Dictionary:
     var sanitized := _sanitize_edge_settings(edge_settings)
+    var default_width := int(DEFAULT_EDGE_DEPTHS.get(edge_name, DEFAULT_EDGE_WIDTH))
     return sanitized.get(edge_name, {
         "type": DEFAULT_EDGE_TERRAINS.get(edge_name, DEFAULT_EDGE_TYPE),
-        "width": DEFAULT_EDGE_WIDTH,
+        "width": default_width,
     })
 
 func get_all_edge_settings() -> Dictionary:
@@ -135,7 +145,8 @@ func _sanitize_edge_settings(source: Dictionary) -> Dictionary:
         var terrain_type := String(entry.get("type", DEFAULT_EDGE_TERRAINS.get(edge_name, DEFAULT_EDGE_TYPE)))
         if not EDGE_TERRAIN_TYPES.has(terrain_type):
             terrain_type = DEFAULT_EDGE_TERRAINS.get(edge_name, DEFAULT_EDGE_TYPE)
-        var width_value := int(entry.get("width", DEFAULT_EDGE_WIDTH))
+        var default_width := int(DEFAULT_EDGE_DEPTHS.get(edge_name, DEFAULT_EDGE_WIDTH))
+        var width_value := int(entry.get("width", default_width))
         sanitized[edge_name] = {
             "type": terrain_type,
             "width": max(0, width_value),

--- a/game/mapgen/HexMapData.gd
+++ b/game/mapgen/HexMapData.gd
@@ -73,6 +73,9 @@ func to_dictionary() -> Dictionary:
                 "is_water": info.get("is_water", false),
                 "is_sea": info.get("is_sea", false),
                 "elev": info.get("elev", 0.0),
+                "river_mask": info.get("river_mask", 0),
+                "river_class": info.get("river_class", 0),
+                "is_mouth": info.get("is_mouth", false),
             }
             hex_array.append(entry)
         result["hexes"] = hex_array

--- a/game/mapgen/HexMapGenerator.gd
+++ b/game/mapgen/HexMapGenerator.gd
@@ -21,10 +21,20 @@ const PHASE_SEQUENCE: Array[StringName] = [
 
 const SUPPORTED_REGIONS: Array[String] = [
     "plains",
+    "valley",
     "hills",
     "mountains",
     "sea",
     "lake",
+]
+
+const RIVER_DIRECTION_BITS: Array[int] = [
+    1 << 0,
+    1 << 1,
+    1 << 2,
+    1 << 3,
+    1 << 4,
+    1 << 5,
 ]
 
 var config: HexMapConfig
@@ -114,10 +124,10 @@ func _default_terrain_phase() -> void:
     map_data.set_stage_result(PHASE_TERRAIN, terrain_state)
 
 func _default_rivers_phase() -> void:
-    rivers_state = {
-        "networks": [],
-    }
+    rivers_state = _generate_rivers()
     map_data.set_stage_result(PHASE_RIVERS, rivers_state)
+    if not terrain_state.is_empty():
+        map_data.set_stage_result(PHASE_TERRAIN, terrain_state)
 
 func _default_biomes_phase() -> void:
     biomes_state = {
@@ -187,6 +197,407 @@ func _generate_terrain() -> Dictionary:
     result["coastline"] = {}
     result["validation"] = {}
     return result
+
+func _generate_rivers() -> Dictionary:
+    var result: Dictionary = {
+        "networks": [],
+        "hexes": {},
+        "validation": {
+            "errors": [],
+            "warnings": [],
+        },
+    }
+    if typeof(terrain_state) != TYPE_DICTIONARY:
+        return result
+    var hex_entries: Dictionary = terrain_state.get("hexes", {})
+    if hex_entries.is_empty():
+        return result
+    var cap: int = max(0, config.rivers_cap)
+    if cap == 0:
+        return result
+    var sources: Array[Vector2i] = _find_mountain_sources(hex_entries)
+    if sources.is_empty():
+        return result
+    if sources.size() > cap:
+        sources = sources.slice(0, cap)
+    var river_hex_data: Dictionary = {}
+    var networks: Array[Dictionary] = []
+    for source_key in sources:
+        var network: Dictionary = _trace_river_from(source_key, hex_entries, river_hex_data)
+        networks.append(network)
+    _compute_river_classes(river_hex_data)
+    _finalize_river_hex_entries(river_hex_data, hex_entries)
+    _refresh_region_counts(hex_entries)
+    result["networks"] = networks
+    result["hexes"] = river_hex_data
+    result["validation"] = _validate_rivers(networks, river_hex_data)
+    return result
+
+func _find_mountain_sources(hex_entries: Dictionary) -> Array[Vector2i]:
+    var peaks: Array[Dictionary] = []
+    for key in hex_entries.keys():
+        var entry: Dictionary = hex_entries.get(key, {})
+        if String(entry.get("region", "")) != "mountains":
+            continue
+        var coord := HexCoord.from_vector2i(key)
+        var elev := float(entry.get("elev", 0.0))
+        var neighbors: Array[HexCoord] = grid.get_neighbor_coords(coord)
+        var is_peak := true
+        var has_lower_neighbor := false
+        for neighbor in neighbors:
+            var neighbor_entry: Dictionary = hex_entries.get(neighbor.to_vector2i(), {})
+            if neighbor_entry.is_empty():
+                continue
+            var neighbor_elev := float(neighbor_entry.get("elev", elev))
+            if neighbor_elev > elev + 0.0005:
+                is_peak = false
+                break
+            if neighbor_elev < elev - 0.0005:
+                has_lower_neighbor = true
+        if not is_peak or not has_lower_neighbor:
+            continue
+        peaks.append({
+            "coord": key,
+            "elev": elev,
+        })
+    peaks.sort_custom(Callable(self, "_compare_peak_entry"))
+    var ordered: Array[Vector2i] = []
+    for peak in peaks:
+        ordered.append(peak.get("coord", Vector2i.ZERO))
+    return ordered
+
+func _compare_peak_entry(a: Dictionary, b: Dictionary) -> bool:
+    var elev_a := float(a.get("elev", 0.0))
+    var elev_b := float(b.get("elev", 0.0))
+    if abs(elev_a - elev_b) < 0.0001:
+        return String(a.get("coord", "")) < String(b.get("coord", ""))
+    return elev_a > elev_b
+
+func _trace_river_from(source_key: Vector2i, hex_entries: Dictionary, river_hex_data: Dictionary) -> Dictionary:
+    var source_entry: Dictionary = hex_entries.get(source_key, {})
+    var path: Array[Vector2i] = []
+    var visited: Dictionary = {}
+    var current_key := source_key
+    var sink_type := ""
+    var sink_coord := source_key
+    if source_entry.is_empty():
+        sink_type = "missing"
+        return {
+            "source": source_key,
+            "path": [source_key],
+            "sink": {
+                "type": sink_type,
+                "coord": sink_coord,
+            },
+        }
+    while true:
+        path.append(current_key)
+        visited[current_key] = true
+        var terrain_entry: Dictionary = hex_entries.get(current_key, {})
+        if path.size() == 1:
+            _mark_river_source(river_hex_data, current_key)
+        _carve_terrain_for_river(hex_entries, current_key)
+        var step: Dictionary = _choose_downhill_step(current_key, hex_entries, visited)
+        if step.is_empty():
+            sink_type = _sink_type_for_hex(current_key, terrain_entry)
+            sink_coord = current_key
+            break
+        var next_key: Vector2i = step.get("coord", current_key)
+        var next_entry: Dictionary = hex_entries.get(next_key, {})
+        var already_traced: bool = river_hex_data.has(next_key)
+        _register_flow_link(river_hex_data, current_key, next_key)
+        if visited.has(next_key):
+            sink_type = "loop"
+            sink_coord = next_key
+            path.append(next_key)
+            break
+        if next_entry.is_empty():
+            sink_type = "void"
+            sink_coord = next_key
+            path.append(next_key)
+            break
+        if next_entry.get("is_sea", false):
+            sink_type = "sea"
+            sink_coord = next_key
+            path.append(next_key)
+            _ensure_river_hex_entry(river_hex_data, next_key)
+            break
+        if next_entry.get("is_water", false) and String(next_entry.get("region", "")) == "lake":
+            _ensure_river_hex_entry(river_hex_data, next_key)
+        elif already_traced:
+            sink_type = "confluence"
+            sink_coord = next_key
+            path.append(next_key)
+            break
+        current_key = next_key
+    if sink_type == "":
+        sink_type = _sink_type_for_hex(sink_coord, hex_entries.get(sink_coord, {}))
+    if sink_type != "confluence" and sink_type != "missing":
+        var sink_entry := _ensure_river_hex_entry(river_hex_data, sink_coord)
+        sink_entry["sink_type"] = sink_type
+        river_hex_data[sink_coord] = sink_entry
+    return {
+        "source": source_key,
+        "path": path,
+        "sink": {
+            "type": sink_type,
+            "coord": sink_coord,
+        },
+    }
+
+func _mark_river_source(river_hex_data: Dictionary, key: Vector2i) -> void:
+    var entry := _ensure_river_hex_entry(river_hex_data, key)
+    entry["is_source"] = true
+    river_hex_data[key] = entry
+
+func _carve_terrain_for_river(hex_entries: Dictionary, key: Vector2i) -> void:
+    var entry: Dictionary = hex_entries.get(key, {})
+    if entry.is_empty():
+        return
+    if entry.get("is_water", false):
+        return
+    var region := String(entry.get("region", "plains"))
+    if region != "plains":
+        return
+    var coord := HexCoord.from_vector2i(key)
+    var target_elev := _elevation_for("valley", coord)
+    var current_elev := float(entry.get("elev", target_elev))
+    entry["region"] = "valley"
+    entry["is_water"] = false
+    entry["is_sea"] = false
+    entry["elev"] = min(current_elev, target_elev)
+    hex_entries[key] = entry
+
+func _choose_downhill_step(current_key: Vector2i, hex_entries: Dictionary, visited: Dictionary) -> Dictionary:
+    var coord := HexCoord.from_vector2i(current_key)
+    var current_entry: Dictionary = hex_entries.get(current_key, {})
+    var current_elev := float(current_entry.get("elev", 0.0))
+    var downhill: Array[Dictionary] = []
+    var fallback: Array[Dictionary] = []
+    for neighbor in grid.get_neighbor_coords(coord):
+        var neighbor_key := neighbor.to_vector2i()
+        var neighbor_entry: Dictionary = hex_entries.get(neighbor_key, {})
+        if neighbor_entry.is_empty():
+            continue
+        if visited.has(neighbor_key):
+            continue
+        var neighbor_elev := float(neighbor_entry.get("elev", current_elev))
+        var bias := _terrain_preference_bias(String(neighbor_entry.get("region", "plains")), bool(neighbor_entry.get("is_water", false)))
+        var candidate := {
+            "coord": neighbor_key,
+            "elev": neighbor_elev,
+            "score": neighbor_elev + bias,
+        }
+        if neighbor_elev <= current_elev + 0.0005:
+            downhill.append(candidate)
+        else:
+            fallback.append(candidate)
+    if downhill.size() > 0:
+        downhill.sort_custom(Callable(self, "_compare_candidate_score"))
+        return downhill[0]
+    fallback.sort_custom(Callable(self, "_compare_candidate_score"))
+    if fallback.size() > 0:
+        return fallback[0]
+    return {}
+
+func _terrain_preference_bias(region: String, is_water: bool) -> float:
+    if is_water:
+        if region == "lake":
+            return -0.35
+        if region == "sea":
+            return -0.25
+    match region:
+        "lake":
+            return -0.3
+        "valley":
+            return -0.2
+        "plains":
+            return -0.1
+        "hills":
+            return -0.05
+        _:
+            return 0.0
+
+func _compare_candidate_score(a: Dictionary, b: Dictionary) -> bool:
+    var score_a := float(a.get("score", 0.0))
+    var score_b := float(b.get("score", 0.0))
+    if abs(score_a - score_b) < 0.0001:
+        var elev_a := float(a.get("elev", 0.0))
+        var elev_b := float(b.get("elev", 0.0))
+        return elev_a < elev_b
+    return score_a < score_b
+
+func _register_flow_link(river_hex_data: Dictionary, from_key: Vector2i, to_key: Vector2i) -> void:
+    var from_entry := _ensure_river_hex_entry(river_hex_data, from_key)
+    var to_entry := _ensure_river_hex_entry(river_hex_data, to_key)
+    var from_coord := HexCoord.from_vector2i(from_key)
+    var to_coord := HexCoord.from_vector2i(to_key)
+    var direction_index := _direction_index(from_coord, to_coord)
+    if direction_index == -1:
+        return
+    var opposite_index := (direction_index + 3) % 6
+    from_entry["river_mask"] = int(from_entry.get("river_mask", 0)) | RIVER_DIRECTION_BITS[direction_index]
+    to_entry["river_mask"] = int(to_entry.get("river_mask", 0)) | RIVER_DIRECTION_BITS[opposite_index]
+    if not from_entry.has("downstream") or from_entry.get("downstream") == null:
+        from_entry["downstream"] = to_key
+    var upstreams_variant: Variant = to_entry.get("upstreams", [])
+    var upstreams: Array = []
+    if upstreams_variant is Array:
+        upstreams = upstreams_variant
+    if not upstreams.has(from_key):
+        upstreams.append(from_key)
+    to_entry["upstreams"] = upstreams
+    river_hex_data[from_key] = from_entry
+    river_hex_data[to_key] = to_entry
+
+func _ensure_river_hex_entry(river_hex_data: Dictionary, key: Vector2i) -> Dictionary:
+    var entry: Dictionary = river_hex_data.get(key, {})
+    if entry.is_empty():
+        entry = {
+            "coord": key,
+            "river_mask": 0,
+            "river_class": 0,
+            "is_mouth": false,
+            "upstreams": [],
+            "downstream": null,
+            "sink_type": "",
+            "is_source": false,
+        }
+        river_hex_data[key] = entry
+    return entry
+
+func _direction_index(from_coord: HexCoord, to_coord: HexCoord) -> int:
+    var diff := Vector2i(to_coord.q - from_coord.q, to_coord.r - from_coord.r)
+    for i in range(HexCoord.DIRECTIONS.size()):
+        if HexCoord.DIRECTIONS[i] == diff:
+            return i
+    return -1
+
+func _sink_type_for_hex(key: Vector2i, entry: Dictionary) -> String:
+    if entry.get("is_sea", false):
+        return "sea"
+    if entry.get("is_water", false) and String(entry.get("region", "")) == "lake":
+        return "lake"
+    if _is_edge_hex(key):
+        return "edge"
+    return "stalled"
+
+func _is_edge_hex(key: Vector2i) -> bool:
+    var coord := HexCoord.from_vector2i(key)
+    var q := coord.q
+    var r := coord.r
+    var s := -q - r
+    return abs(q) == grid.radius or abs(r) == grid.radius or abs(s) == grid.radius
+
+func _compute_river_classes(river_hex_data: Dictionary) -> void:
+    var cache: Dictionary = {}
+    for key in river_hex_data.keys():
+        _resolve_river_class(key, river_hex_data, cache, 0)
+    for key in cache.keys():
+        var entry: Dictionary = river_hex_data.get(key, {})
+        entry["river_class"] = cache.get(key, 1)
+        river_hex_data[key] = entry
+
+func _resolve_river_class(key: Vector2i, river_hex_data: Dictionary, cache: Dictionary, depth: int) -> int:
+    if cache.has(key):
+        return int(cache[key])
+    if depth > 128:
+        cache[key] = 1
+        return 1
+    var entry: Dictionary = river_hex_data.get(key, {})
+    var upstreams_variant: Variant = entry.get("upstreams", [])
+    var upstreams: Array = []
+    if upstreams_variant is Array:
+        upstreams = upstreams_variant
+    if upstreams.is_empty():
+        cache[key] = 1
+        return 1
+    var values: Array[int] = []
+    for upstream_key in upstreams:
+        values.append(_resolve_river_class(upstream_key, river_hex_data, cache, depth + 1))
+    var max_value := 0
+    var max_count := 0
+    for value in values:
+        if value > max_value:
+            max_value = value
+            max_count = 1
+        elif value == max_value:
+            max_count += 1
+    var class_value := max_value
+    if max_count >= 2:
+        class_value += 1
+    class_value = clampi(class_value, 1, 3)
+    cache[key] = class_value
+    return class_value
+
+func _finalize_river_hex_entries(river_hex_data: Dictionary, hex_entries: Dictionary) -> void:
+    for key in river_hex_data.keys():
+        var entry: Dictionary = river_hex_data.get(key, {})
+        var downstream: Variant = entry.get("downstream")
+        var is_mouth := false
+        if downstream == null:
+            var sink_type := String(entry.get("sink_type", ""))
+            if sink_type == "sea" or sink_type == "lake" or sink_type == "edge":
+                is_mouth = true
+        else:
+            var downstream_entry: Dictionary = hex_entries.get(downstream, {})
+            if downstream_entry.get("is_water", false):
+                is_mouth = true
+        entry["is_mouth"] = is_mouth
+        river_hex_data[key] = entry
+        var terrain_entry: Dictionary = hex_entries.get(key, {})
+        if terrain_entry.is_empty():
+            continue
+        terrain_entry["river_mask"] = int(entry.get("river_mask", 0))
+        terrain_entry["river_class"] = int(entry.get("river_class", 0))
+        terrain_entry["is_mouth"] = bool(entry.get("is_mouth", false))
+        hex_entries[key] = terrain_entry
+
+func _refresh_region_counts(hex_entries: Dictionary) -> void:
+    var region_info: Dictionary = terrain_state.get("regions", {})
+    if typeof(region_info) != TYPE_DICTIONARY:
+        return
+    var counts := _compute_region_counts(hex_entries)
+    var land_count := 0
+    for region_type in counts.keys():
+        if String(region_type) != "sea":
+            land_count += int(counts[region_type])
+    region_info["counts"] = counts
+    region_info["land_count"] = land_count
+    region_info["sea_count"] = int(counts.get("sea", 0))
+    terrain_state["regions"] = region_info
+
+func _validate_rivers(networks: Array[Dictionary], river_hex_data: Dictionary) -> Dictionary:
+    var errors: Array[String] = []
+    var warnings: Array[String] = []
+    for network in networks:
+        var sink: Dictionary = network.get("sink", {})
+        var sink_type := String(sink.get("type", ""))
+        if sink_type == "" or sink_type == "stalled" or sink_type == "void" or sink_type == "loop" or sink_type == "missing":
+            var source: Vector2i = network.get("source", Vector2i.ZERO)
+            var coords := "%d,%d" % [source.x, source.y]
+            var message := "River from %s does not reach a valid sink (type=%s)." % [coords, sink_type]
+            if not errors.has(message):
+                errors.append(message)
+    for key in river_hex_data.keys():
+        var entry: Dictionary = river_hex_data.get(key, {})
+        var upstreams_variant: Variant = entry.get("upstreams", [])
+        var upstreams: Array = []
+        if upstreams_variant is Array:
+            upstreams = upstreams_variant
+        if upstreams.is_empty():
+            continue
+        if not entry.has("downstream") or entry.get("downstream") == null:
+            var sink_type := String(entry.get("sink_type", ""))
+            if sink_type != "sea" and sink_type != "lake" and sink_type != "edge":
+                var coords := "%d,%d" % [key.x, key.y]
+                var message := "River hex %s terminates without a sink." % coords
+                if not errors.has(message):
+                    errors.append(message)
+    return {
+        "errors": errors,
+        "warnings": warnings,
+    }
 
 func _collect_all_coords() -> Array[HexCoord]:
     var coords: Array[HexCoord] = []
@@ -331,6 +742,7 @@ func _elevation_for(region_type: String, coord: HexCoord) -> float:
     var base_levels := {
         "sea": 0.0,
         "lake": 0.12,
+        "valley": 0.2,
         "plains": 0.5,
         "hills": 0.68,
         "mountains": 0.9,
@@ -338,6 +750,7 @@ func _elevation_for(region_type: String, coord: HexCoord) -> float:
     var jitter := {
         "sea": 0.02,
         "lake": 0.04,
+        "valley": 0.03,
         "plains": 0.05,
         "hills": 0.04,
         "mountains": 0.03,

--- a/game/mapgen/HexMapGenerator.gd
+++ b/game/mapgen/HexMapGenerator.gd
@@ -270,7 +270,11 @@ func _compare_peak_entry(a: Dictionary, b: Dictionary) -> bool:
     var elev_a := float(a.get("elev", 0.0))
     var elev_b := float(b.get("elev", 0.0))
     if abs(elev_a - elev_b) < 0.0001:
-        return String(a.get("coord", "")) < String(b.get("coord", ""))
+        var coord_a: Vector2i = a.get("coord", Vector2i.ZERO)
+        var coord_b: Vector2i = b.get("coord", Vector2i.ZERO)
+        if coord_a.x == coord_b.x:
+            return coord_a.y < coord_b.y
+        return coord_a.x < coord_b.x
     return elev_a > elev_b
 
 func _trace_river_from(source_key: Vector2i, hex_entries: Dictionary, river_hex_data: Dictionary) -> Dictionary:

--- a/game/tests/RunTests.gd
+++ b/game/tests/RunTests.gd
@@ -1,0 +1,14 @@
+extends SceneTree
+
+const RiversSuite := preload("res://tests/mapgen/HexMapGeneratorRiversTest.gd")
+
+func _initialize() -> void:
+    var suite := RiversSuite.new()
+    var failure_count := suite.run()
+    if failure_count > 0:
+        for message in suite.get_failures():
+            push_error("[tests] %s" % message)
+        quit(1)
+        return
+    print("[tests] HexMapGenerator rivers suite passed")
+    quit()

--- a/game/tests/mapgen/HexMapGeneratorRiversTest.gd
+++ b/game/tests/mapgen/HexMapGeneratorRiversTest.gd
@@ -1,0 +1,129 @@
+extends RefCounted
+class_name HexMapGeneratorRiversTestSuite
+
+const HexMapGeneratorScript := preload("res://mapgen/HexMapGenerator.gd")
+const HexMapConfigScript := preload("res://mapgen/HexMapConfig.gd")
+
+var _failures: Array[String] = []
+
+func run() -> int:
+    _failures.clear()
+    _test_river_traces_downhill_and_sets_masks()
+    _test_confluence_promotes_river_class()
+    _test_lake_outlet_extends_to_sea()
+    return _failures.size()
+
+func get_failures() -> Array[String]:
+    return _failures.duplicate()
+
+func _record_failure(message: String) -> void:
+    _failures.append(message)
+
+func _check(condition: bool, message: String) -> void:
+    if not condition:
+        _record_failure(message)
+
+func _make_generator(radius: int, rivers_cap: int = 6) -> HexMapGenerator:
+    var config := HexMapConfigScript.new(12345, radius, 1, rivers_cap)
+    return HexMapGeneratorScript.new(config)
+
+func _make_hex_entry(q: int, r: int, region: String, elev: float) -> Dictionary:
+    var is_sea := region == "sea"
+    var is_water := is_sea or region == "lake"
+    return {
+        "coord": Vector2i(q, r),
+        "region": region,
+        "is_water": is_water,
+        "is_sea": is_sea,
+        "elev": elev,
+    }
+
+func _apply_terrain(generator: HexMapGenerator, hexes: Dictionary) -> void:
+    var terrain := {
+        "hexes": hexes,
+        "regions": {},
+        "coastline": {},
+        "validation": {},
+    }
+    generator.terrain_state = terrain
+    generator.map_data.set_stage_result(HexMapGeneratorScript.PHASE_TERRAIN, terrain)
+
+func _test_river_traces_downhill_and_sets_masks() -> void:
+    var generator := _make_generator(2)
+    var hexes: Dictionary = {}
+    hexes[Vector2i(0, 0)] = _make_hex_entry(0, 0, "mountains", 0.9)
+    hexes[Vector2i(0, -1)] = _make_hex_entry(0, -1, "plains", 0.42)
+    hexes[Vector2i(0, -2)] = _make_hex_entry(0, -2, "sea", 0.03)
+    _apply_terrain(generator, hexes)
+
+    generator._default_rivers_phase()
+
+    var rivers_state: Dictionary = generator.rivers_state
+    var networks: Array = rivers_state.get("networks", [])
+    _check(networks.size() == 1, "Expected a single river network from mountain peak to sea.")
+    if networks.size() > 0:
+        var path: Array = networks[0].get("path", [])
+        _check(path.size() == 3, "River path should include source, channel and mouth.")
+        if path.size() == 3:
+            _check(path[0] == Vector2i(0, 0), "River should originate at the mountain peak.")
+            _check(path[1] == Vector2i(0, -1), "River should traverse the adjacent channel hex.")
+            _check(path[2] == Vector2i(0, -2), "River should terminate in the sea hex.")
+    var middle: Dictionary = generator.terrain_state.get("hexes", {}).get(Vector2i(0, -1), {})
+    _check(String(middle.get("region", "")) == "valley", "River flow should carve plains into a valley.")
+    var mask := int(middle.get("river_mask", 0))
+    _check((mask & (1 << 2)) != 0 and (mask & (1 << 5)) != 0, "Valley hex should contain upstream and downstream river mask bits.")
+    _check(int(middle.get("river_class", 0)) == 1, "Single-source rivers should default to class 1.")
+    var sea_hex: Dictionary = generator.terrain_state.get("hexes", {}).get(Vector2i(0, -2), {})
+    _check(bool(sea_hex.get("is_mouth", false)), "Sea hex should be marked as a river mouth.")
+    var errors: Array = rivers_state.get("validation", {}).get("errors", [])
+    _check(errors.is_empty(), "River validation should report no errors for a complete sink.")
+
+func _test_confluence_promotes_river_class() -> void:
+    var generator := _make_generator(3)
+    var hexes: Dictionary = {}
+    hexes[Vector2i(-1, 0)] = _make_hex_entry(-1, 0, "mountains", 0.94)
+    hexes[Vector2i(1, -1)] = _make_hex_entry(1, -1, "mountains", 0.93)
+    hexes[Vector2i(0, -1)] = _make_hex_entry(0, -1, "plains", 0.38)
+    hexes[Vector2i(0, -2)] = _make_hex_entry(0, -2, "sea", 0.02)
+    _apply_terrain(generator, hexes)
+
+    generator._default_rivers_phase()
+
+    var valley: Dictionary = generator.terrain_state.get("hexes", {}).get(Vector2i(0, -1), {})
+    _check(String(valley.get("region", "")) == "valley", "Confluence tile should convert to a valley.")
+    var mask := int(valley.get("river_mask", 0))
+    _check((mask & (1 << 0)) != 0, "Confluence should include flow from east.")
+    _check((mask & (1 << 2)) != 0, "Confluence should include downstream flow toward the sea.")
+    _check((mask & (1 << 4)) != 0, "Confluence should include flow from west.")
+    _check(int(valley.get("river_class", 0)) == 2, "Merged rivers should increase the river class to 2.")
+    var rivers_state: Dictionary = generator.rivers_state
+    var errors: Array = rivers_state.get("validation", {}).get("errors", [])
+    _check(errors.is_empty(), "Confluence network should still reach a valid sink.")
+
+func _test_lake_outlet_extends_to_sea() -> void:
+    var generator := _make_generator(4)
+    var hexes: Dictionary = {}
+    hexes[Vector2i(0, 0)] = _make_hex_entry(0, 0, "mountains", 0.91)
+    hexes[Vector2i(0, -1)] = _make_hex_entry(0, -1, "plains", 0.48)
+    hexes[Vector2i(1, -1)] = _make_hex_entry(1, -1, "lake", 0.24)
+    hexes[Vector2i(1, -2)] = _make_hex_entry(1, -2, "plains", 0.18)
+    hexes[Vector2i(1, -3)] = _make_hex_entry(1, -3, "sea", 0.03)
+    _apply_terrain(generator, hexes)
+
+    generator._default_rivers_phase()
+
+    var lake_hex: Dictionary = generator.terrain_state.get("hexes", {}).get(Vector2i(1, -1), {})
+    var mask := int(lake_hex.get("river_mask", 0))
+    _check((mask & (1 << 4)) != 0 and (mask & (1 << 2)) != 0, "Lake should have both inlet and outlet masks set.")
+    var outlet: Dictionary = generator.terrain_state.get("hexes", {}).get(Vector2i(1, -2), {})
+    _check(String(outlet.get("region", "")) == "valley", "Lake outlet plains should erode into a valley.")
+    var rivers_state: Dictionary = generator.rivers_state
+    var errors: Array = rivers_state.get("validation", {}).get("errors", [])
+    _check(errors.is_empty(), "Lake outlet scenario should not report validation errors.")
+    var networks: Array = rivers_state.get("networks", [])
+    var sink: Dictionary = {}
+    if networks.size() > 0:
+        sink = networks[0].get("sink", {})
+    _check(String(sink.get("type", "")) == "sea", "Lake outlet should continue until reaching the sea.")
+    var sea_hex: Dictionary = generator.terrain_state.get("hexes", {}).get(Vector2i(1, -3), {})
+    _check(bool(sea_hex.get("is_mouth", false)), "Downstream sea hex should be flagged as a river mouth.")

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -202,7 +202,7 @@ func _configure_param_ranges() -> void:
     rivers_spinbox.min_value = 0.0
     rivers_spinbox.max_value = 12.0
     radius_spinbox.step = 1.0
-    radius_spinbox.min_value = 6.0
+    radius_spinbox.min_value = max(1.0, min(6.0, float(HEX_MAP_CONFIG_SCRIPT.DEFAULT_MAP_RADIUS)))
     radius_spinbox.max_value = 48.0
 
 func _ensure_edge_controls() -> void:
@@ -469,7 +469,7 @@ func _get_radius_limit() -> int:
         return max(1, _current_config.map_radius)
     if radius_spinbox != null:
         return max(1, int(round(radius_spinbox.value)))
-    return 24
+    return HEX_MAP_CONFIG_SCRIPT.DEFAULT_MAP_RADIUS
 
 func _update_edge_width_limits() -> void:
     var max_radius := _get_radius_limit()

--- a/game/ui/MapSetupScreen.gd
+++ b/game/ui/MapSetupScreen.gd
@@ -409,7 +409,8 @@ func _apply_edge_settings_to_controls() -> void:
         var type_button: OptionButton = entry.get("type") as OptionButton
         var width_spin: SpinBox = entry.get("width") as SpinBox
         var setting: Dictionary = settings.get(edge_id, {})
-        var terrain_type := String(setting.get("type", "plains"))
+        var default_terrain := String(HEX_MAP_CONFIG_SCRIPT.DEFAULT_EDGE_TERRAINS.get(edge_id, HEX_MAP_CONFIG_SCRIPT.DEFAULT_EDGE_TYPE))
+        var terrain_type := String(setting.get("type", default_terrain))
         var width_value := int(setting.get("width", 0))
         if type_button != null:
             _select_option_by_metadata(type_button, terrain_type)


### PR DESCRIPTION
## Summary
- generate rivers from mountain peaks, carve routes toward lakes or seas, and flag invalid networks
- export per-hex river mask, class, and mouth metadata with updated terrain accounting
- add river routing test suite and runner covering downhill paths, confluences, and lake outlets

## Testing
- CI_AUTO_QUIT=1 godot --headless --path game --check res://mapgen/HexMapGenerator.gd
- CI_AUTO_QUIT=1 godot --headless --path game --check res://mapgen/HexMapData.gd
- CI_AUTO_QUIT=1 godot --headless --path game --check res://tests/mapgen/HexMapGeneratorRiversTest.gd
- CI_AUTO_QUIT=1 godot --headless --path game --check res://tests/RunTests.gd
- CI_AUTO_QUIT=1 godot --headless --path game --script res://tests/RunTests.gd


------
https://chatgpt.com/codex/tasks/task_e_68cdbe3bae7c83289a5ddd962cb0b2e4