### PR TITLE
feat: refresh map view land instancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changed
 - Plains carved by rivers automatically downgrade to valleys and lakes prefer to open downstream outlets when terrain allows.
 - Map generation defaults now start with mountain-mountain-hills-sea-sea-hills edge bands, edge depths 2/2/2/2/5/2, edge jitter 3, and medium random features.
 - Default map seed now initializes to 12345 and the base radius default is 16 so generated maps start from the requested large baseline.
+- Map preview terrain now reuses a shared land base prism, scales per-hex elevation for surface placement, and deterministically cycles hill and mountain variants by coordinate.
 Fixed
 - Corrected river peak ordering to compare coordinates without using the nonexistent `String` constructor in Godot 4.
 - Map preview river batching now preloads all twelve river tiles, classifies masks by canonical rotations, and renders each combination with its dedicated mesh.


### PR DESCRIPTION
## Summary
- refactor MapView to share a land base prism layer and per-region surface multimeshes
- scale land elevation from map data, reposition surface meshes, and choose hill/mountain variants deterministically
- update changelog entry for the refreshed map preview terrain instancing

## Testing
- godot --headless --path game --check game/ui/MapView.gd --quit
- tools/check.sh game

------
https://chatgpt.com/codex/tasks/task_e_68cde43a39ac8328827c1839e79b73bc